### PR TITLE
Fix bug in milestone datepicker edit and remove unused variable

### DIFF
--- a/includes/html.php
+++ b/includes/html.php
@@ -576,7 +576,7 @@ function cpm_milestone_form( $project_id, $milestone = null ) {
             </div>
 
             <div class="item due">
-                <input name="milestone_due" autocomplete="off" class="datepicker required" type="text" id="milestone_due" value="<?php echo esc_attr( $due ); ?>" placeholder="<?php esc_attr_e( 'Due date', 'cpm' ); ?>">
+                <input name="milestone_due" autocomplete="off" class="datepicker required" type="text" value="<?php echo esc_attr( $due ); ?>" placeholder="<?php esc_attr_e( 'Due date', 'cpm' ); ?>">
             </div>
 
             <div class="item detail">


### PR DESCRIPTION
I had tracked this down to the hidden form that exists on the page for "add milestone". It was getting added to both, and the change was actually happening on the first, hidden one. With this new info, I found someone else had seen this same issue of datepicker being added to more than one item that shares the same id. Some info here: http://davidjs.com/2011/01/jquery-datepicker-duplicate-id/

Since the id isn't being used anywhere that I can find, I removed it, and it fixes the problem. Also worth noting that two items with the same id should never exist anyway. We could maybe add a php conditional for grabbing and applying an id on existing milestones, which should avoid this problem if we need an id for something.
