### PR TITLE
Fix: incorrect current user removal

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -162,14 +162,13 @@ function cpm_user_checkboxes( $project_id ) {
     $users    = $pro_obj->get_users( $project_id );
     $cur_user = get_current_user_id();
 
-    // remove current logged in user from list
-    if ( array_key_exists( $cur_user, $users ) ) {
-
-        $arr_index = array_search( $cur_user, $users );
-        unset( $users[$arr_index] );
-    }
-
     foreach ( $users as $key => $user ) {
+        // remove current logged in user from list
+        if ( $user['id'] == $cur_user ) {
+            unset( $users[$key] );
+            continue;
+        }
+        // prepare to sort users by name
         $sort[$key] = strtolower( $user['name'] );
     }
 


### PR DESCRIPTION
Removing current user from checkboxes considering that "$users" array comming from "get_users" function has users ids as keys while "get_users" function returns indexed not associative multidimensional array. Fix: add the removal logic to loop.