### PR TITLE
Show full name on project overview page

### DIFF
--- a/views/assets/src/components/project-overview/overview.vue
+++ b/views/assets/src/components/project-overview/overview.vue
@@ -126,7 +126,7 @@
                         <div class="list-left">
                             <img :alt="ucfirst(user.display_name)" :src="user.avatar_url" class="avatar avatar-34 photo" height="34" width="34">
                             <a :title="ucfirst(user.display_name)" :href="myTaskRedirect(user.id)">
-                                {{ ucfirst(cutString(user.display_name, 8, true)) }}
+                                {{ ucfirst(user.display_name) }}
                             </a>
                             <span v-for="role in user.roles.data" :key="role.id">{{ __( role.title, 'wedevs-project-manager') }}</span>
                         </div>


### PR DESCRIPTION
We were unable to see the full name on the overview page so, this commit will show that correctly.