### PR TITLE
Add "Project Switcher" in front-end to fix JS error

### DIFF
--- a/core/WP/Frontend.php
+++ b/core/WP/Frontend.php
@@ -65,6 +65,7 @@ class Frontend {
 		add_action( 'plugins_loaded', array( $this, 'pm_content_filter_url' ) );
         add_filter( 'plugin_action_links_' . PM_BASENAME , array( $this, 'plugin_action_links' ) );
         add_filter( 'in_plugin_update_message-' . PM_BASENAME , array( $this, 'upgrade_notice' ), 10, 2 );
+	add_action( 'wp_footer', array( $this, 'switch_project_html' ) );
         add_action( 'admin_footer', array( $this, 'switch_project_html' ) );
         add_action( 'admin_init', array( $this, 'redirect_after_activate' ) );
         add_action('admin_bar_menu', array( $this, 'pm_toolbar_search_button' ), 999);


### PR DESCRIPTION
If the "Project Switcher HTML" is not loaded in the front-end, the "pmglobal.js" file throws JavaScript error.