### PR TITLE
Fix: Category not assigned

### DIFF
--- a/src/Project/Controllers/Project_Controller.php
+++ b/src/Project/Controllers/Project_Controller.php
@@ -254,7 +254,7 @@ class Project_Controller {
 		$project->update_model( $data );
 
 		// Establishing relationships
-		$category_ids = intval( $request->get_param( 'categories' ));
+		$category_ids = map_deep( $request->get_param( 'categories' ), 'intval' );
 		if ( $category_ids ) {
 			$project->categories()->sync( $category_ids );
 		}

--- a/src/Project/Controllers/Project_Controller.php
+++ b/src/Project/Controllers/Project_Controller.php
@@ -215,7 +215,7 @@ class Project_Controller {
 		$project = Project::create( $data );
 		add_option('projectId_git_bit_hash_'.$project->id , sha1(strtotime("now").$project->id));
 		// Establishing relationships
-		$category_ids = intval( $request->get_param( 'categories' ) );
+		$category_ids = map_deep( $request->get_param( 'categories' ), 'intval' );
 		
 		if ( $category_ids ) {
 			$project->categories()->sync( $category_ids );


### PR DESCRIPTION
Fixes #537 
while adding any projects to any category, not working. WP PM >> Projects >> Edit >> Save it under any category >> Save. But after reloading the page, projects are not saving.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved how multiple category selections are processed, ensuring each selected category is accurately recognized.
	- Enhanced the processing of project creation data for more reliable and comprehensive handling of user input.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->