### PR TITLE
:bug: [fix] load Pusher scripts only when app_key and cluster are set

### DIFF
--- a/src/Pusher/Pusher.php
+++ b/src/Pusher/Pusher.php
@@ -55,6 +55,10 @@ class Pusher {
     }
 
     public function scripts() {
+        if ( ! Auth::app_key() || ! Auth::app_cluster() ) {
+            return;
+        }
+        
         $path = filemtime( pm_config('define.path') . '/src/Pusher/views/assets/vendor/pusher-v5.0.2.min.js' );
         wp_enqueue_script( 'pm-pusher-library', pm_config('define.url') . 'src/Pusher/views/assets/vendor/pusher-v5.0.2.min.js', array('jquery'), $path, true );
         


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability by ensuring scripts and styles are only loaded when required authentication keys are present.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->