### PR TITLE
Fix sensitive data exposure vulnerability in /pm/v2/users API endpoints

### DIFF
--- a/core/Permissions/Create_Users.php
+++ b/core/Permissions/Create_Users.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace WeDevs\PM\Core\Permissions;
+
+use WeDevs\PM\Core\Permissions\Abstract_Permission;
+
+class Create_Users extends Abstract_Permission {
+    /**
+     * Check if the current user has permission to create users.
+     *
+     * @return bool|\WP_Error
+     */
+    public function check() {
+        $user_id = get_current_user_id();
+
+        if ( empty( $user_id ) ) {
+            return new \WP_Error(
+                'rest_forbidden',
+                __( 'You must be logged in to access this resource.', 'wedevs-project-manager' ),
+                array( 'status' => 401 )
+            );
+        }
+
+        // Only allow administrators and users with create_users capability
+        if ( current_user_can( 'create_users' ) ) {
+            return true;
+        }
+
+        return new \WP_Error(
+            'rest_forbidden',
+            __( 'You do not have permission to create users.', 'wedevs-project-manager' ),
+            array( 'status' => 403 )
+        );
+    }
+}

--- a/core/Permissions/List_Users.php
+++ b/core/Permissions/List_Users.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace WeDevs\PM\Core\Permissions;
+
+use WeDevs\PM\Core\Permissions\Abstract_Permission;
+
+class List_Users extends Abstract_Permission {
+    /**
+     * Check if the current user has permission to list users.
+     *
+     * @return bool|\WP_Error
+     */
+    public function check() {
+        $user_id = get_current_user_id();
+
+        if ( empty( $user_id ) ) {
+            return new \WP_Error(
+                'rest_forbidden',
+                __( 'You must be logged in to access this resource.', 'wedevs-project-manager' ),
+                array( 'status' => 401 )
+            );
+        }
+
+        // Allow administrators and users with list_users capability
+        if ( current_user_can( 'list_users' ) ) {
+            return true;
+        }
+
+        // Allow users with PM manage capability
+        if ( wedevs_pm_user_can_access( wedevs_pm_manager_cap_slug() ) ) {
+            return true;
+        }
+
+        return new \WP_Error(
+            'rest_forbidden',
+            __( 'You do not have permission to list users.', 'wedevs-project-manager' ),
+            array( 'status' => 403 )
+        );
+    }
+}

--- a/routes/user.php
+++ b/routes/user.php
@@ -1,24 +1,26 @@
 <?php
 
 use WeDevs\PM\Core\Router\Router;
-use WeDevs\PM\Core\Permissions\Authentic;
 
 $wedevs_pm_router = Router::singleton();
 
+// User listing endpoints - require list_users capability or PM manager role
 $wedevs_pm_router->get( 'users', 'WeDevs/PM/User/Controllers/User_Controller@index' )
-    ->permission(['WeDevs\PM\Core\Permissions\Authentic']);
-$wedevs_pm_router->post( 'users', 'WeDevs/PM/User/Controllers/User_Controller@store' )
-    ->permission(['WeDevs\PM\Core\Permissions\Authentic']);
+    ->permission(['WeDevs\PM\Core\Permissions\List_Users']);
 $wedevs_pm_router->get( 'users/{id}', 'WeDevs/PM/User/Controllers/User_Controller@show' )
-    ->permission(['WeDevs\PM\Core\Permissions\Authentic']);
-
+    ->permission(['WeDevs\PM\Core\Permissions\List_Users']);
 $wedevs_pm_router->get( 'users/search', 'WeDevs/PM/User/Controllers/User_Controller@search' )
-    ->permission(['WeDevs\PM\Core\Permissions\Authentic']);
+    ->permission(['WeDevs\PM\Core\Permissions\List_Users']);
+$wedevs_pm_router->get( 'user-all-projects', 'WeDevs/PM/User/Controllers/User_Controller@get_user_all_projects' )
+    ->permission(['WeDevs\PM\Core\Permissions\List_Users']);
+
+// User creation - require create_users capability
+$wedevs_pm_router->post( 'users', 'WeDevs/PM/User/Controllers/User_Controller@store' )
+    ->permission(['WeDevs\PM\Core\Permissions\Create_Users']);
+
 //$wedevs_pm_router->put( 'users/{user_id}/roles', 'WeDevs/PM/User/Controllers/User_Controller@update_role' )
 //    ->permission(['WeDevs\PM\Core\Permissions\Project_Manage_Capability']);
 
+// User meta update - already checks manage_options in controller
 $wedevs_pm_router->post( 'save_users_map_name', 'WeDevs/PM/User/Controllers/User_Controller@save_users_map_name' )
-    ->permission(['WeDevs\PM\Core\Permissions\Authentic']);
-
-$wedevs_pm_router->get( 'user-all-projects', 'WeDevs/PM/User/Controllers/User_Controller@get_user_all_projects' )
     ->permission(['WeDevs\PM\Core\Permissions\Authentic']);


### PR DESCRIPTION
Security: Fix broken access control in User API endpoints (IDOR)
Close [276](https://github.com/weDevsOfficial/pm-pro/issues/276)
The /wp-json/pm/v2/users endpoints were accessible to any authenticated 
user (including subscribers), exposing sensitive user data such as emails, 
usernames, and external account identifiers (GitHub/Bitbucket).

Changes:
- Added List_Users permission class requiring list_users capability or PM manager role
- Added Create_Users permission class requiring create_users capability
- Updated routes/user.php to use proper capability-based permissions

Affected endpoints:
- GET /pm/v2/users
- GET /pm/v2/users/{id}
- GET /pm/v2/users/search
- GET /pm/v2/user-all-projects
- POST /pm/v2/users

Severity: Medium (CVSS 6.5)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added granular permission controls for user management operations, enabling administrators to separately control who can create users and who can list/view users.
  * Introduced a new endpoint for retrieving all user projects with proper access restrictions.

* **Improvements**
  * Refactored user-related access controls to enforce specific user management capabilities instead of generic authentication checks.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->