### PR TITLE
Update mixin.js

### DIFF
--- a/views/assets/src/helpers/mixin/mixin.js
+++ b/views/assets/src/helpers/mixin/mixin.js
@@ -297,7 +297,8 @@ export default {
                 return '';
             }
 
-            return word.replace(/\w/, c => c.toUpperCase())
+            // Properly handle Unicode characters (including Slovak č, ľ, š, ž, etc.)
+            return word.charAt(0).toUpperCase() + word.slice(1);
         },
 
 


### PR DESCRIPTION
Fix Slovak/Unicode character capitalization in ucfirst function Close #408  

Problem:
- The ucfirst() function used regex /\w/ which only matches ASCII characters
- Slovak characters (č, ľ, š, ž) and other Unicode characters were skipped
- This caused "člen" to display as "ČLen" (capitalizing 2nd letter instead of 1st)
- Affected task list names, task titles, and user display names

Solution:
- Replaced regex-based capitalization with charAt(0).toUpperCase()
- Now properly handles all Unicode characters including diacritical marks

Files changed:
- views/assets/src/helpers/mixin/mixin.js (ucfirst function)

Impact:
- Fixes capitalization for Slovak, Czech, and other languages with diacritics
- Applies to task lists, task titles, comments, and user names throughout the plugin

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved text capitalization handling for Unicode and international characters. Non-ASCII characters (such as Slovak letters) now display with correct capitalization when processed, ensuring accurate and consistent text formatting across different language inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->