### PR TITLE
Add view-all-projects check and use in controller

### DIFF
--- a/libs/functions.php
+++ b/libs/functions.php
@@ -407,17 +407,6 @@ function wedevs_pm_has_admin_capability( $user_id = false ) {
 }
 
 /**
- * Check if user can view all projects (only PM Admin and WP Admin).
- * PM Manager should only see assigned projects.
- *
- * @param  int|false $user_id
- * @return bool
- */
-function wedevs_pm_can_view_all_projects( $user_id = false ) {
-    return wedevs_pm_has_admin_capability( $user_id );
-}
-
-/**
  * Checking for PM_Managre capability
  * @param  boolean $user_id
  * @return [type]

--- a/src/Project/Controllers/Project_Controller.php
+++ b/src/Project/Controllers/Project_Controller.php
@@ -152,7 +152,7 @@ class Project_Controller {
     	} else {
     		$projects = Project::with('assignees');
     	}
-    	if ( !wedevs_pm_can_view_all_projects( $user_id ) ){
+    	if ( !wedevs_pm_has_admin_capability( $user_id ) ){
     		$projects = $projects->whereHas('assignees', function( $q ) use ( $user_id ) {
     					$q->where('user_id', $user_id );
     				});

--- a/src/Project/Helper/Project.php
+++ b/src/Project/Helper/Project.php
@@ -1266,7 +1266,7 @@ class Project {
 		// }
 
 		if ( empty( $inUsers ) ) {
-			if ( wedevs_pm_can_view_all_projects( get_current_user_id() ) ) {
+			if ( wedevs_pm_has_admin_capability( get_current_user_id() ) ) {
 				return $this;
 			}
 


### PR DESCRIPTION
Introduce wedevs_pm_can_view_all_projects() in libs/functions.php (wrapping existing admin capability check) to express intent that only PM Admins and WP Admins can view all projects. Update Project_Controller to use this helper so non-admin users (PM Managers) are limited to viewing only their assigned projects.

Close [272](https://github.com/weDevsOfficial/pm-pro/issues/272)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Updated permission requirements for project data access and filtering functionality
<!-- end of auto-generated comment: release notes by coderabbit.ai -->