### PR TITLE
Fix email notifications not being sent (Ticket #317556)

### DIFF
--- a/core/Notifications/Emails/Complete_Task_Notification.php
+++ b/core/Notifications/Emails/Complete_Task_Notification.php
@@ -12,7 +12,7 @@ class Complete_Task_Notification extends Email {
 
     function __construct() {
 
-        add_action('pm_changed_task_status_notification', array($this, 'trigger'), 10, 2 );
+        add_action('wedevs_pm_changed_task_status_notification', array($this, 'trigger'), 10, 2 );
     }
 
     public function trigger( $task, $old_value ) {

--- a/core/Notifications/Emails/New_Comment_Notification.php
+++ b/core/Notifications/Emails/New_Comment_Notification.php
@@ -18,7 +18,7 @@ class New_Comment_Notification extends Email {
     
     function __construct() {
 
-        add_action('pm_after_new_comment_notification', array($this, 'trigger'), 10, 2 );
+        add_action('wedevs_pm_after_new_comment_notification', array($this, 'trigger'), 10, 2 );
     }
 
     public function trigger( $commentData, $request ) {

--- a/core/Notifications/Emails/New_Message_Notification.php
+++ b/core/Notifications/Emails/New_Message_Notification.php
@@ -12,7 +12,7 @@ class New_Message_Notification extends Email {
     
     function __construct() {
 
-        add_action('pm_after_new_message_notification', array($this, 'trigger'), 10, 2 );
+        add_action('wedevs_pm_after_new_message_notification', array($this, 'trigger'), 10, 2 );
     }
 
     public function trigger( $message, $request ) {

--- a/core/Notifications/Emails/New_Project_Notification.php
+++ b/core/Notifications/Emails/New_Project_Notification.php
@@ -11,7 +11,7 @@ class New_Project_Notification extends Email {
     
     function __construct() {
 
-        add_action('pm_after_new_project_notification', array($this, 'trigger'), 10, 2 );
+        add_action('wedevs_pm_after_new_project_notification', array($this, 'trigger'), 10, 2 );
     }
 
     public function trigger( $project, $data ) {

--- a/core/Notifications/Emails/New_Task_Notification.php
+++ b/core/Notifications/Emails/New_Task_Notification.php
@@ -11,7 +11,7 @@ class New_Task_Notification extends Email {
     
     function __construct() {
 
-        add_action('pm_after_create_task_notification', array($this, 'trigger'), 10, 2 );
+        add_action('wedevs_pm_after_create_task_notification', array($this, 'trigger'), 10, 2 );
     }
 
     public function trigger( $task, $data ) {

--- a/core/Notifications/Emails/Update_Comment_Notification.php
+++ b/core/Notifications/Emails/Update_Comment_Notification.php
@@ -13,7 +13,7 @@ class Update_Comment_Notification extends Email {
     
     function __construct() {
 
-        add_action('pm_after_update_comment_notification', array($this, 'trigger'), 10, 2 );
+        add_action('wedevs_pm_after_update_comment_notification', array($this, 'trigger'), 10, 2 );
     }
 
     public function trigger( $commentData, $request ) {

--- a/core/Notifications/Emails/Update_Message_Notification.php
+++ b/core/Notifications/Emails/Update_Message_Notification.php
@@ -12,7 +12,7 @@ class Update_Message_Notification extends Email {
     
     function __construct() {
 
-        add_action('pm_after_update_message_notification', array($this, 'trigger'), 10, 2 );
+        add_action('wedevs_pm_after_update_message_notification', array($this, 'trigger'), 10, 2 );
     }
 
     public function trigger( $message, $request ) {

--- a/core/Notifications/Emails/Update_Project_Notification.php
+++ b/core/Notifications/Emails/Update_Project_Notification.php
@@ -11,7 +11,7 @@ class Update_Project_Notification extends Email {
     
     function __construct() {
 
-        add_action('pm_after_update_project_notification', array($this, 'trigger'), 10, 2 );
+        add_action('wedevs_pm_after_update_project_notification', array($this, 'trigger'), 10, 2 );
     }
 
     public function trigger( $project, $data ) {

--- a/core/Notifications/Emails/Update_Task_Notification.php
+++ b/core/Notifications/Emails/Update_Task_Notification.php
@@ -11,7 +11,7 @@ class Update_Task_Notification extends Email {
     
     function __construct() {
 
-        add_action('pm_after_update_task_notification', array($this, 'trigger'), 10, 2 );
+        add_action('wedevs_pm_after_update_task_notification', array($this, 'trigger'), 10, 2 );
     }
 
     public function trigger( $task, $data ) {


### PR DESCRIPTION
Fix email notifications not being sent (Ticket #317556)

Resolved hook name mismatch where notification handlers registered without the wedevs_ prefix, but hooks were fired with it. All 9 notification types affected: tasks, projects, messages, and comments.

Close [293](https://github.com/weDevsOfficial/pm-pro/issues/293)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated notification system references for improved internal consistency across task management, project, comment, and message notifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->