### PR TITLE
fix: task counts, drag reorder, and meta plumbing

### DIFF
--- a/src/Task/Controllers/Task_Controller.php
+++ b/src/Task/Controllers/Task_Controller.php
@@ -1252,7 +1252,8 @@ class Task_Controller {
                     ) SEPARATOR '|'
                 ) as assignees"
             )
-            ->selectRaw( "count($comment.id) as total_comment" )
+            // DISTINCT avoids cartesian inflation from sibling LEFT JOINs.
+            ->selectRaw( "count(DISTINCT $comment.id) as total_comment" )
             ->whereIn( $task . '.id', $task_ids )
 
             ->leftJoin( $list, function( $join ) use($task, $list) {

--- a/src/Task/Helper/Task.php
+++ b/src/Task/Helper/Task.php
@@ -249,13 +249,16 @@ class Task {
 
 	private function set_item_meta( $item, $task ) {
 		$item['meta'] = empty( $task->meta ) ? [] : $task->meta;
-		
+
 		$item['meta']['total_comment']     = $task->total_comments;
 		$item['meta']['can_complete_task'] = $this->wedevs_pm_user_can_complete_task( $task );
 		$item['meta']['total_files']       = $task->total_files;
 		$item['meta']['total_assignee']    = count( $task->assignees['data'] );
+		if ( ! isset( $item['meta']['total_sub_task'] ) ) {
+			$item['meta']['total_sub_task'] = 0;
+		}
 		$item['meta']['privacy']           = $task->is_private;
-		
+
 		return $item;
 	}
 

--- a/src/Task/Transformers/Task_Transformer.php
+++ b/src/Task/Transformers/Task_Transformer.php
@@ -125,6 +125,7 @@ class Task_Transformer extends TransformerAbstract {
             'total_files'       => $item->files->count(),
             'total_board'       => $item->boards->count(),
             'total_assignee'    => $item->assignees->count(),
+            'total_sub_task'    => 0,
             'can_complete_task' => wedevs_pm_user_can_complete_task( $item ),
         ] );
         

--- a/src/Task_List/Transformers/List_Task_Transformer.php
+++ b/src/Task_List/Transformers/List_Task_Transformer.php
@@ -83,8 +83,9 @@ class List_Task_Transformer extends TransformerAbstract {
     public function meta( Task $item ) {
         $metas = [
             'can_complete_task' => $this->wedevs_pm_user_can_complete_task( $item ),
-            'total_comment' => $item->total_comment,
-            'privacy'       => (int) $item->is_private,
+            'total_comment'     => (int) $item->total_comment,
+            'total_sub_task'    => 0,
+            'privacy'           => (int) $item->is_private,
         ];
 
 	    return $metas;

--- a/views/assets/src/components/my-tasks/MyTasksPage/parts/MyTaskRow.jsx
+++ b/views/assets/src/components/my-tasks/MyTasksPage/parts/MyTaskRow.jsx
@@ -3,7 +3,7 @@ import React, { useState } from "react";
 import { Badge } from "@components/ui/badge";
 import { UserAvatar } from '@components/common/UserAvatar';
 import TaskLabelBadges from "@components/tasks/TaskLabelBadges";
-import { Check, MessageSquare, Lock } from "lucide-react";
+import { Check, MessageSquare, Lock, Layers } from "lucide-react";
 import {
   isTaskComplete,
   formatPmDate,
@@ -87,6 +87,13 @@ export default function MyTaskRow({ task, projectTitle, onToggle, onOpen }) {
         <Badge variant="destructive" className="text-[11px] px-1.5 py-0 h-4 shrink-0">
           {__('Overdue', 'wedevs-project-manager')}
         </Badge>
+      )}
+
+      {(task.meta?.total_sub_task ?? 0) > 0 && (
+        <span className="flex items-center gap-0.5 text-[15px] text-pm-text-muted shrink-0">
+          <Layers className="h-3.5 w-3.5" />
+          {task.meta.total_sub_task}
+        </span>
       )}
 
       {(task.meta?.total_comment ?? 0) > 0 && (

--- a/views/assets/src/components/projects/MilestonesPage/parts/MilestoneCard.jsx
+++ b/views/assets/src/components/projects/MilestonesPage/parts/MilestoneCard.jsx
@@ -35,7 +35,7 @@ import ProBadge from "@components/common/ProBadge";
 import {
   Trash2, MoreHorizontal, CheckCircle, Clock,
   Lock, Unlock, Pencil, MessageSquare, Minus,
-  ListChecks, ChevronDown, Calendar, Timer, Flag,
+  ListChecks, ChevronDown, Calendar, Timer, Flag, Layers,
 } from "lucide-react";
 import TaskCheckbox from "./TaskCheckbox";
 import MilestoneHealthBadge from "./MilestoneHealthBadge";
@@ -319,6 +319,7 @@ export default function MilestoneCard({ milestone, projectId, onEdit, onImportTa
                 const dueDate = taskDateStr(task.due_date);
                 const est = taskEstTime(task);
                 const commentCount = parseInt(task.meta?.total_comment ?? task.comments_count ?? 0, 10) || 0;
+                const subtaskCount = parseInt(task.meta?.total_sub_task ?? 0, 10) || 0;
                 const taskIsPrivate = checkPrivate(task.meta?.privacy);
                 const priorityColor = task.priority >= 3 ? 'text-red-500' : task.priority === 2 ? 'text-amber-500' : task.priority === 1 ? 'text-blue-500' : '';
                 const overdueTask = isOverdue(task.due_date, task.status);
@@ -364,6 +365,12 @@ export default function MilestoneCard({ milestone, projectId, onEdit, onImportTa
                         <Timer className="h-3.5 w-3.5" />
                         <span>{est}</span>
                       </div>
+                    )}
+                    {subtaskCount > 0 && (
+                      <span className="flex items-center gap-0.5 text-[13px] text-pm-text-muted shrink-0">
+                        <Layers className="h-3.5 w-3.5" />
+                        {subtaskCount}
+                      </span>
                     )}
                     {commentCount > 0 && (
                       <span className="flex items-center gap-0.5 text-[13px] text-pm-text-muted shrink-0">

--- a/views/assets/src/components/tasks/TaskListSection.jsx
+++ b/views/assets/src/components/tasks/TaskListSection.jsx
@@ -183,16 +183,42 @@ export default function TaskListSection({ list, projectId, showLabels, isInbox =
       setDragOverTaskIdx(null)
       return
     }
-    // Optimistic reorder
+    // Optimistic visible reorder
     dispatch(reorderTasksLocal({ listId: list.id, fromIndex: fromIdx, toIndex: toIdx }))
-    // Build orders for API
-    const tasks = [...incompleteTasks]
-    const [moved] = tasks.splice(fromIdx, 1)
-    tasks.splice(toIdx, 0, moved)
-    const orders = tasks.map((t, i) => ({ id: t.id, index: i }))
-
     dragTaskIdx.current = null
     setDragOverTaskIdx(null)
+
+    // Build reordered visible list
+    const visibleTasks = [...incompleteTasks]
+    const [moved] = visibleTasks.splice(fromIdx, 1)
+    visibleTasks.splice(toIdx, 0, moved)
+
+    // Preload remaining tasks so the backend renumbers every order in one shot;
+    // unsent IDs would keep stale orders and scramble the list on refresh.
+    const unloadedTasks = []
+    if (incompleteTasks.length < totalIncomplete) {
+      try {
+        let loadedIds = visibleTasks.map(t => t.id)
+        while (loadedIds.length < totalIncomplete) {
+          const res = await api.get(`projects/${projectId}/task-lists/${list.id}/more/tasks`, {
+            task_ids: loadedIds,
+            status: 0,
+          })
+          const newTasks = res?.data?.tasks?.data ?? res?.data ?? []
+          if (newTasks.length === 0) break
+          unloadedTasks.push(...newTasks)
+          loadedIds = [...loadedIds, ...newTasks.map(t => t.id)]
+        }
+      } catch {
+        // Fall back to visible-only ordering on preload failure.
+      }
+    }
+
+    // Backend stores `index` verbatim; load is ORDER BY order DESC — top needs
+    // highest index.
+    const allTasks = [...visibleTasks, ...unloadedTasks]
+    const lastIdx = allTasks.length - 1
+    const orders = allTasks.map((t, i) => ({ id: t.id, index: lastIdx - i }))
 
     try {
       await dispatch(sortTasks({ projectId, listId: list.id, taskId: moved.id, orders, receive: 0 })).unwrap()
@@ -201,7 +227,7 @@ export default function TaskListSection({ list, projectId, showLabels, isInbox =
       dispatch(reorderTasksLocal({ listId: list.id, fromIndex: toIdx, toIndex: fromIdx }))
       toast.error(__('Failed to reorder tasks', 'wedevs-project-manager'))
     }
-  }, [dispatch, projectId, list.id, incompleteTasks, toast, __])
+  }, [dispatch, projectId, list.id, incompleteTasks, totalIncomplete, api, toast, __])
 
   const handleTaskDragEnd = useCallback(() => {
     dragTaskIdx.current = null

--- a/views/assets/src/components/tasks/TaskRow.jsx
+++ b/views/assets/src/components/tasks/TaskRow.jsx
@@ -42,6 +42,7 @@ import {
   Unlock,
   Crown,
   Github,
+  Layers,
 } from 'lucide-react'
 import MoveTaskDialog from './MoveTaskDialog'
 import {
@@ -259,6 +260,13 @@ export default function TaskRow({ task, projectId, listId, draggable: isDraggabl
         <Badge variant="destructive" className="text-[11px] px-1.5 py-0 h-4 shrink-0">
           Overdue
         </Badge>
+      )}
+
+      {(task.meta?.total_sub_task ?? 0) > 0 && (
+        <span className="flex items-center gap-0.5 text-[15px] text-pm-text-muted shrink-0">
+          <Layers className="h-3.5 w-3.5" />
+          {task.meta.total_sub_task}
+        </span>
       )}
 
       {/* Comment count */}


### PR DESCRIPTION
Drag-reorder on the task list scrambled order after refresh because the React handler sent ascending indexes while the backend loads ORDER BY boardable.order DESC. The handler now inverts the index (top = highest) and preloads any unloaded incomplete tasks before saving so the backend renumbers every row in one shot.

Subtask count now follows the comment-count pattern via meta.total_sub_task across List_Task_Transformer, Task_Transformer, and Helper Task. TaskRow, MyTaskRow, and MilestoneCard read it the same way they read total_comment, keeping counts coherent after syncTaskInLists merges the fetchTask payload.

Also fixes cartesian inflation on total_comment in get_tasks SQL (count became multiplied by the assignees JOIN) via COUNT DISTINCT.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed incorrect comment count totals that were appearing on your tasks.

* **New Features**
  * Added subtask count indicators throughout the interface—visible in task lists and milestone cards—for improved task visibility and better overall workflow organization.
  * Improved task reordering and sorting functionality to more reliably handle your complete task workflows during drag-and-drop operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/weDevsOfficial/wp-project-manager/pull/602)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->