### PR TITLE
security: strip PolinRider .gitignore tamper marker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,4 +27,3 @@ wp-project-manager.zip
 CLAUDE.local.md
 .claude/settings.local.json
 .claude/agent-memory/
-config.bat


### PR DESCRIPTION
## Summary

Strip the PolinRider supply-chain worm tamper marker from `.gitignore`.

The line `config.bat` was added by the worm to hide its orchestrator binary from git tracking. Removing the line restores normal `.gitignore` semantics so the binary, if present, will show up in `git status` and be blocked by the supply-chain guard hooks.

## Background

- Public reference: https://github.com/OpenSourceMalware/PolinRider
- Worm active in `weDevsOfficial` + `wp-erp` orgs since 2026-04-30.
- Today (2026-05-20) 30+ org repos were force-pushed by attacker using a leaked OAuth token. All known attack vectors on the affected developer machine have been remediated (gh CLI OAuth revoked, SSH key rotated).

## Test plan

- [ ] `grep -c "^config\.bat$" .gitignore` → 0
- [ ] CI build still passes