### PR TITLE
fix: notify_users crash, avatar fallback, and client-route layout flags

### DIFF
--- a/src/Pusher/Libs/action.php
+++ b/src/Pusher/Libs/action.php
@@ -29,11 +29,15 @@ function wedevs_pm_pusher_normalize_user_ids( $value ) {
         return [];
     }
 
-    if ( is_array( $value ) ) {
-        return array_values( array_filter( array_map( 'intval', $value ) ) );
-    }
+    $ids = is_array( $value )
+        ? array_map( 'intval', $value )
+        : array_map( 'intval', explode( ',', (string) $value ) );
 
-    return array_values( array_filter( array_map( 'intval', explode( ',', (string) $value ) ) ) );
+    $ids = array_filter( $ids, static function ( $id ) {
+        return $id > 0;
+    } );
+
+    return array_values( array_unique( $ids ) );
 }
 
 function wedevs_pm_pusher_has_task_update_content( $model ) {

--- a/src/Pusher/Libs/action.php
+++ b/src/Pusher/Libs/action.php
@@ -24,6 +24,18 @@ function wedevs_pm_pusher_is_admin_request() {
     return empty( $pages['project'] );
 }
 
+function wedevs_pm_pusher_normalize_user_ids( $value ) {
+    if ( empty( $value ) ) {
+        return [];
+    }
+
+    if ( is_array( $value ) ) {
+        return array_values( array_filter( array_map( 'intval', $value ) ) );
+    }
+
+    return array_values( array_filter( array_map( 'intval', explode( ',', (string) $value ) ) ) );
+}
+
 function wedevs_pm_pusher_has_task_update_content( $model ) {
 
     $content = [];
@@ -271,7 +283,7 @@ function wedevs_pm_pusher_after_new_comment( $comment, $params ) {
     $event    = wedevs_pm_pusher_get_event( 'new_comment' );
     $channels = [];
 
-    $users = empty( $params['notify_users'] ) ? [] : explode( ',', $params['notify_users'] );
+    $users = wedevs_pm_pusher_normalize_user_ids( $params['notify_users'] ?? null );
 
     $message = sprintf(
         '%s %s <a class="pm-pro-pusher-anchor" target="_blank" style="color: #fff; text-decoration: underline;" href="%s">%s</a>',
@@ -355,7 +367,7 @@ function wedevs_pm_pusher_after_update_comment( $comment, $params ) {
     $event    = wedevs_pm_pusher_get_event( 'new_comment' );
     $channels = [];
 
-    $users = empty( $params['notify_users'] ) ? [] : explode( ',', $params['notify_users'] );
+    $users = wedevs_pm_pusher_normalize_user_ids( $params['notify_users'] ?? null );
 
     $nc_message = sprintf(
         '<strong>%1$s</strong> %2$s <strong>%3$s</strong>',
@@ -442,7 +454,7 @@ function wedevs_pm_pusher_after_new_message( $message, $params, $discussion_boar
     $creator  = $discussion_board->creator->display_name;
     $title    = $discussion_board->title;
 
-    $users = empty( $params['notify_users'] ) ? [] : explode( ',', $params['notify_users'] );
+    $users = wedevs_pm_pusher_normalize_user_ids( $params['notify_users'] ?? null );
     $url     = wedevs_pm_pusher_message_url( $params['project_id'], $message['data']['id'] );
     $nc_message = sprintf(
         '<strong>%1$s</strong> %2$s <strong>%3$s</strong>',
@@ -490,7 +502,7 @@ function wedevs_pm_pusher_after_update_message( $mesage, $params, $discussion_bo
     $updater = $discussion_board->updater->display_name;
     $title   = $discussion_board->title;
 
-    $users = empty( $params['notify_users'] ) ? [] : explode( ',', $params['notify_users'] );
+    $users = wedevs_pm_pusher_normalize_user_ids( $params['notify_users'] ?? null );
     $url = wedevs_pm_pusher_message_url( $params['project_id'], $mesage['data']['id'] );
 
     $nc_message = sprintf(

--- a/views/assets/src/components/common/CreateUserDialog.jsx
+++ b/views/assets/src/components/common/CreateUserDialog.jsx
@@ -48,7 +48,16 @@ export default function CreateUserDialog({ open, onOpenChange, defaultSeed = '',
       onOpenChange?.(false)
       onCreated?.(created)
     } catch (err) {
-      const msg = typeof err === 'string' ? err : err?.message || __('Could not create user', 'wedevs-project-manager')
+      const errorMap = {
+        create_user_failed: __('Could not create user', 'wedevs-project-manager'),
+        no_id_returned: __('Server did not return a user. Try again.', 'wedevs-project-manager'),
+      }
+      const fallback = __('Could not create user', 'wedevs-project-manager')
+      const raw = typeof err === 'string' ? err : err?.message
+      // Treat internal snake_case keys as non-user-friendly; only surface
+      // strings that contain whitespace (real sentences from WP_Error etc.).
+      const looksFriendly = typeof raw === 'string' && /\s/.test(raw)
+      const msg = (typeof raw === 'string' && errorMap[raw]) || (looksFriendly ? raw : fallback)
       toast.error(msg)
     } finally {
       setSubmitting(false)

--- a/views/assets/src/components/common/CreateUserDialog.jsx
+++ b/views/assets/src/components/common/CreateUserDialog.jsx
@@ -1,0 +1,119 @@
+import { __ } from '@wordpress/i18n'
+import React, { useEffect, useState } from 'react'
+import { useAppDispatch } from '@store/index'
+import { createUser } from '@store/projectsSlice'
+import { useToast } from '@hooks/useToast'
+import { Button } from '@components/ui/button'
+import { Label } from '@components/ui/label'
+import { Input } from '@components/ui/input'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@components/ui/dialog'
+import { Loader2 } from 'lucide-react'
+
+export default function CreateUserDialog({ open, onOpenChange, defaultSeed = '', onCreated }) {
+  const dispatch = useAppDispatch()
+  const toast = useToast()
+  const [submitting, setSubmitting] = useState(false)
+  const [form, setForm] = useState({ username: '', first_name: '', last_name: '', email: '' })
+
+  useEffect(() => {
+    if (!open) return
+    const seed = (defaultSeed || '').trim()
+    const looksLikeEmail = /.+@.+\..+/.test(seed)
+    setForm({
+      username: looksLikeEmail ? seed.split('@')[0] : seed,
+      first_name: '',
+      last_name: '',
+      email: looksLikeEmail ? seed : '',
+    })
+  }, [open, defaultSeed])
+
+  const handleSubmit = async (e) => {
+    e.preventDefault()
+    if (!form.username.trim() || !form.email.trim()) {
+      toast.error(__('Username and email are required', 'wedevs-project-manager'))
+      return
+    }
+    setSubmitting(true)
+    try {
+      const created = await dispatch(createUser(form)).unwrap()
+      if (!created?.id) throw new Error('no_id_returned')
+      toast.success(__('User created', 'wedevs-project-manager'))
+      onOpenChange?.(false)
+      onCreated?.(created)
+    } catch (err) {
+      const msg = typeof err === 'string' ? err : err?.message || __('Could not create user', 'wedevs-project-manager')
+      toast.error(msg)
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-md" data-pm-dialog>
+        <DialogHeader>
+          <DialogTitle>{__('Create a new user', 'wedevs-project-manager')}</DialogTitle>
+          <DialogDescription>
+            {__('Create a WordPress user. They will be available to add to projects.', 'wedevs-project-manager')}
+          </DialogDescription>
+        </DialogHeader>
+        <form onSubmit={handleSubmit} className="space-y-3">
+          <div className="space-y-1.5">
+            <Label htmlFor="pm-cu-username">{__('Username', 'wedevs-project-manager')}</Label>
+            <Input
+              id="pm-cu-username"
+              value={form.username}
+              onChange={(e) => setForm((f) => ({ ...f, username: e.target.value }))}
+              required
+              autoFocus
+            />
+          </div>
+          <div className="grid grid-cols-2 gap-3">
+            <div className="space-y-1.5">
+              <Label htmlFor="pm-cu-first">{__('First Name', 'wedevs-project-manager')}</Label>
+              <Input
+                id="pm-cu-first"
+                value={form.first_name}
+                onChange={(e) => setForm((f) => ({ ...f, first_name: e.target.value }))}
+              />
+            </div>
+            <div className="space-y-1.5">
+              <Label htmlFor="pm-cu-last">{__('Last Name', 'wedevs-project-manager')}</Label>
+              <Input
+                id="pm-cu-last"
+                value={form.last_name}
+                onChange={(e) => setForm((f) => ({ ...f, last_name: e.target.value }))}
+              />
+            </div>
+          </div>
+          <div className="space-y-1.5">
+            <Label htmlFor="pm-cu-email">{__('Email', 'wedevs-project-manager')}</Label>
+            <Input
+              id="pm-cu-email"
+              type="email"
+              value={form.email}
+              onChange={(e) => setForm((f) => ({ ...f, email: e.target.value }))}
+              required
+            />
+          </div>
+          <DialogFooter>
+            <Button type="button" variant="outline" onClick={() => onOpenChange?.(false)} disabled={submitting}>
+              {__('Cancel', 'wedevs-project-manager')}
+            </Button>
+            <Button type="submit" disabled={submitting}>
+              {submitting && <Loader2 className="h-5 w-5 mr-2 animate-spin" />}
+              {submitting ? __('Creating...', 'wedevs-project-manager') : __('Create User', 'wedevs-project-manager')}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/views/assets/src/components/common/RichTextEditor.jsx
+++ b/views/assets/src/components/common/RichTextEditor.jsx
@@ -8,6 +8,7 @@ import Placeholder from '@tiptap/extension-placeholder'
 import Mention from '@tiptap/extension-mention'
 import { cn } from '@lib/utils'
 import { Button } from '@components/ui/button'
+import { UserAvatar } from '@components/common/UserAvatar'
 import {
   Tooltip,
   TooltipContent,
@@ -144,13 +145,8 @@ const MentionList = forwardRef(({ items, command, clientRect, editorElement }, r
           }}
           onMouseDown={(e) => { e.preventDefault(); command(user) }}
         >
-          {user.avatar_url ? (
-            <img src={user.avatar_url} alt="" style={{ height: 24, width: 24, borderRadius: '50%', objectFit: 'cover', flexShrink: 0 }} />
-          ) : (
-            <span style={{ height: 24, width: 24, borderRadius: '50%', background: 'hsl(var(--muted))', display: 'flex', alignItems: 'center', justifyContent: 'center', flexShrink: 0, fontSize: 11, fontWeight: 600, color: 'hsl(var(--muted-foreground))' }}>
-              {(user.display_name || user.name || '?')[0].toUpperCase()}
-            </span>
-          )}
+          <UserAvatar user={{ avatar_url: user.avatar_url, display_name: user.display_name || user.name }} size="md" />
+
           <span style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{user.display_name || user.name}</span>
         </button>
       ))}

--- a/views/assets/src/components/common/UserAvatar.jsx
+++ b/views/assets/src/components/common/UserAvatar.jsx
@@ -17,10 +17,23 @@ function getInitials(name) {
   return (parts[0][0] + parts[parts.length - 1][0]).toUpperCase();
 }
 
+function normalizeAvatarUrl(url) {
+  if (!url) return '';
+  if (!/gravatar\.com\/avatar/i.test(url)) return url;
+  // Force `d=404` so missing gravatars return HTTP 404. Radix AvatarImage
+  // then fires onError and the AvatarFallback (initials) renders. Any other
+  // default (blank/mp/identicon/custom URL) loads successfully and would
+  // suppress the fallback.
+  if (/[?&]d=/i.test(url)) {
+    return url.replace(/([?&])d=[^&#]*/i, '$1d=404');
+  }
+  return url + (url.includes('?') ? '&' : '?') + 'd=404';
+}
+
 export function UserAvatar({ user, size = 'md', className, fallbackClassName, ...props }) {
   const s = sizeMap[size] || sizeMap.md;
   const name = user?.display_name || user?.username || '';
-  const avatarUrl = user?.avatar_url || '';
+  const avatarUrl = normalizeAvatarUrl(user?.avatar_url || '');
 
   return (
     <Avatar className={cn(s.avatar, 'shrink-0', className)} {...props}>

--- a/views/assets/src/components/layout/AppLayout.jsx
+++ b/views/assets/src/components/layout/AppLayout.jsx
@@ -3,11 +3,10 @@ import { Outlet } from 'react-router-dom'
 import { AppSidebar } from './AppSidebar'
 import { TopBar } from './TopBar'
 import { ProjectSubNavBar } from './ProjectSubNavBar'
-import { useHideSidebar, useHideSubNav } from '@/router/routeRegistry'
+import { useLayoutFlags } from '@/router/routeRegistry'
 
 export function AppLayout() {
-  const hideSidebar = useHideSidebar()
-  const hideSubNav = useHideSubNav()
+  const { hideSidebar, hideSubNav } = useLayoutFlags()
 
   useEffect(() => {
     document.body.classList.add('pm-fullscreen-settings')

--- a/views/assets/src/components/layout/AppLayout.jsx
+++ b/views/assets/src/components/layout/AppLayout.jsx
@@ -3,8 +3,12 @@ import { Outlet } from 'react-router-dom'
 import { AppSidebar } from './AppSidebar'
 import { TopBar } from './TopBar'
 import { ProjectSubNavBar } from './ProjectSubNavBar'
+import { useHideSidebar, useHideSubNav } from '@/router/routeRegistry'
 
 export function AppLayout() {
+  const hideSidebar = useHideSidebar()
+  const hideSubNav = useHideSubNav()
+
   useEffect(() => {
     document.body.classList.add('pm-fullscreen-settings')
     return () => document.body.classList.remove('pm-fullscreen-settings')
@@ -12,10 +16,10 @@ export function AppLayout() {
 
   return (
     <div className="pm-app-layout flex h-full overflow-hidden bg-pm-surface-muted">
-      <AppSidebar />
+      {!hideSidebar && <AppSidebar />}
       <div className="flex-1 flex flex-col overflow-hidden">
         <TopBar />
-        <ProjectSubNavBar />
+        {!hideSubNav && <ProjectSubNavBar />}
         <main className="flex-1 overflow-y-auto">
           <Outlet />
         </main>

--- a/views/assets/src/components/layout/FrontendLayout.jsx
+++ b/views/assets/src/components/layout/FrontendLayout.jsx
@@ -5,6 +5,7 @@ import { usePermissions } from '@hooks/usePermissions'
 import { cn } from '@lib/utils'
 import { UserAvatar } from '@components/common/UserAvatar'
 import { AppSidebar } from '@components/layout/AppSidebar'
+import { useHideSidebar } from '@/router/routeRegistry'
 import {
   FolderKanban, CheckSquare, Calendar, BarChart3,
   Menu, X, LogOut, Crown, Tag,
@@ -41,6 +42,8 @@ export function FrontendLayout() {
   const navItems = getNavItems(isPro, isAdmin || canManage).filter(item => !(item.hideWhenPro && isPro))
   const userName = currentUser?.data?.display_name || currentUser?.display_name || 'User'
   const userAvatar = currentUser?.data?.avatar_url || currentUser?.avatar_url || ''
+
+  const hideSidebar = useHideSidebar()
 
   const isActive = (path) => location.pathname.startsWith(path) || location.hash?.includes(path)
 
@@ -139,7 +142,7 @@ export function FrontendLayout() {
 
       {/* Sidebar + Main content */}
       <div className="flex min-h-[calc(100vh-56px)]">
-        <AppSidebar />
+        {!hideSidebar && <AppSidebar />}
         <main className="flex-1 overflow-auto p-6">
           <Outlet />
         </main>

--- a/views/assets/src/components/layout/TopBar.jsx
+++ b/views/assets/src/components/layout/TopBar.jsx
@@ -480,11 +480,7 @@ export function TopBar() {
                   const actor = n.actor?.data || n.actor || {}
                   return (
                     <div key={n.id} className="flex items-start gap-3 px-5 py-3 hover:bg-muted/20 transition-colors">
-                      {actor.avatar_url ? (
-                        <img src={actor.avatar_url} className="h-7 w-7 rounded-full shrink-0 mt-0.5" alt="" />
-                      ) : (
-                        <div className="h-7 w-7 rounded-full bg-muted shrink-0 mt-0.5" />
-                      )}
+                      <UserAvatar user={actor} size="md" className="mt-0.5" />
                       <div className="flex-1 min-w-0">
                         <p className="text-sm text-pm-text-primary leading-relaxed">{msg}</p>
                         {n.created_at && (

--- a/views/assets/src/components/projects/ProjectCreateSheet.jsx
+++ b/views/assets/src/components/projects/ProjectCreateSheet.jsx
@@ -39,12 +39,12 @@ import {
 } from '@components/ui/popover'
 import {
   Command,
-  CommandEmpty,
   CommandGroup,
   CommandInput,
   CommandItem,
   CommandList,
 } from '@components/ui/command'
+import CreateUserDialog from '@components/common/CreateUserDialog'
 
 import { Plus, X, Loader2, UserPlus } from 'lucide-react'
 
@@ -82,6 +82,9 @@ export function ProjectCreateSheet() {
   const [searchQuery, setSearchQuery] = useState('')
   const [searchResults, setSearchResults] = useState([])
   const [selectedUsers, setSelectedUsers] = useState([])
+
+  // ── Create-user dialog state ────────────────────────────
+  const [createUserOpen, setCreateUserOpen] = useState(false)
   const [popoverOpen, setPopoverOpen] = useState(false)
 
   const searchTimerRef = useRef(null)
@@ -187,6 +190,21 @@ export function ProjectCreateSheet() {
   const handleRemoveUser = useCallback((userId) => {
     setSelectedUsers((prev) => prev.filter((u) => u.id !== userId))
   }, [])
+
+  const openCreateUserDialog = useCallback(() => {
+    setPopoverOpen(false)
+    setCreateUserOpen(true)
+  }, [])
+
+  const handleUserCreated = useCallback(
+    (created) => {
+      const defaultRoleId = roles.length > 0 ? roles[0].id : 1
+      setSelectedUsers((prev) => [...prev, { ...created, roleId: defaultRoleId }])
+      setSearchQuery('')
+      setSearchResults([])
+    },
+    [roles],
+  )
 
   // ── Change user role ────────────────────────────────────
 
@@ -365,7 +383,15 @@ export function ProjectCreateSheet() {
                     )}
 
                     {!searchingUsers && searchQuery.trim().length >= 2 && searchResults.length === 0 && (
-                      <CommandEmpty>{__('No users found', 'wedevs-project-manager')}</CommandEmpty>
+                      <div className="px-3 py-4 text-center space-y-2">
+                        <p className="text-sm text-muted-foreground">
+                          {__('No user found named', 'wedevs-project-manager')}{' '}
+                          <span className="font-medium text-pm-text-primary">&quot;{searchQuery}&quot;</span>
+                        </p>
+                        <Button type="button" size="sm" onClick={openCreateUserDialog}>
+                          <UserPlus className="h-4 w-4 mr-1" />{__('Create User', 'wedevs-project-manager')}
+                        </Button>
+                      </div>
                     )}
 
                     {searchResults.length > 0 && (
@@ -483,6 +509,13 @@ export function ProjectCreateSheet() {
           </Button>
         </SheetFooter>
       </SheetContent>
+
+      <CreateUserDialog
+        open={createUserOpen}
+        onOpenChange={setCreateUserOpen}
+        defaultSeed={searchQuery}
+        onCreated={handleUserCreated}
+      />
     </Sheet>
   )
 }

--- a/views/assets/src/components/projects/ProjectCreateSheet.jsx
+++ b/views/assets/src/components/projects/ProjectCreateSheet.jsx
@@ -92,6 +92,12 @@ export function ProjectCreateSheet() {
   // ── Reset form when sheet opens ─────────────────────────
 
   useEffect(() => {
+    if (!isOpen) {
+      // Sheet closed (X, ESC, parent dispatch): drop any open child dialog so
+      // it doesn't flash open next time the sheet mounts.
+      setCreateUserOpen(false)
+      return
+    }
     if (isOpen) {
       setTitleError('')
       setSearchQuery('')

--- a/views/assets/src/components/projects/ProjectOverview.jsx
+++ b/views/assets/src/components/projects/ProjectOverview.jsx
@@ -31,7 +31,6 @@ import {
 } from "@components/ui/popover";
 import {
   Command,
-  CommandEmpty,
   CommandGroup,
   CommandInput,
   CommandItem,
@@ -46,6 +45,7 @@ import {
 } from "@components/ui/select";
 import { useAppDispatch, useAppSelector } from "@store/index";
 import { fetchRoles } from "@store/projectsSlice";
+import CreateUserDialog from "@components/common/CreateUserDialog";
 import { Area, AreaChart, XAxis, CartesianGrid } from "recharts";
 import {
   ChartContainer,
@@ -76,6 +76,7 @@ export default function ProjectOverview() {
   const [memberSearch, setMemberSearch] = useState('');
   const [memberResults, setMemberResults] = useState([]);
   const [searchingMembers, setSearchingMembers] = useState(false);
+  const [createUserOpen, setCreateUserOpen] = useState(false);
   const [pendingUser, setPendingUser] = useState(null);
   const [pendingRoleId, setPendingRoleId] = useState(null);
   const searchTimer = useRef(null);
@@ -106,9 +107,9 @@ export default function ProjectOverview() {
     searchTimer.current = setTimeout(async () => {
       setSearchingMembers(true);
       try {
-        const res = await api.get('users', { search: value.trim() });
-        const existing = new Set((project?.assignees?.data ?? []).map(u => u.id));
-        setMemberResults((res.data ?? []).filter(u => !existing.has(u.id)));
+        const res = await api.get('users/search', { query: value.trim() });
+        const existing = new Set((project?.assignees?.data ?? []).map(u => parseInt(u.id)));
+        setMemberResults((res.data ?? []).filter(u => !existing.has(parseInt(u.id))));
       } catch { setMemberResults([]); }
       setSearchingMembers(false);
     }, 300);
@@ -479,7 +480,19 @@ export default function ProjectOverview() {
                       </div>
                     )}
                     {!searchingMembers && memberSearch.trim().length >= 2 && memberResults.length === 0 && (
-                      <CommandEmpty>{__("No users found", 'wedevs-project-manager')}</CommandEmpty>
+                      <div className="px-3 py-4 text-center space-y-2">
+                        <p className="text-sm text-muted-foreground">
+                          {__("No user found named", 'wedevs-project-manager')}{' '}
+                          <span className="font-medium text-pm-text-primary">&quot;{memberSearch}&quot;</span>
+                        </p>
+                        <Button
+                          type="button"
+                          size="sm"
+                          onClick={() => { setMemberPopover(false); setCreateUserOpen(true); }}
+                        >
+                          <UserPlus className="h-4 w-4 mr-1" />{__("Create User", 'wedevs-project-manager')}
+                        </Button>
+                      </div>
                     )}
                     {memberResults.length > 0 && (
                       <CommandGroup>
@@ -593,6 +606,18 @@ export default function ProjectOverview() {
           </p>
         )}
       </div>
+
+      <CreateUserDialog
+        open={createUserOpen}
+        onOpenChange={setCreateUserOpen}
+        defaultSeed={memberSearch}
+        onCreated={(created) => {
+          setMemberSearch('');
+          setMemberResults([]);
+          setMemberPopover(true);
+          handleSelectUserForAdd(created);
+        }}
+      />
     </div>
   );
 }

--- a/views/assets/src/index.jsx
+++ b/views/assets/src/index.jsx
@@ -156,7 +156,11 @@ function AppRoutes() {
           <Route path="woo-project" element={<ProFeaturePlaceholder title={__("WooCommerce Project", 'wedevs-project-manager')} description={__("Automatically create projects from WooCommerce orders with product-based templates.", 'wedevs-project-manager')} icon={ShoppingCart} mockKey="woo-project" />} />
         )}
 
-        <Route path="*" element={<Navigate to="/projects" replace />} />
+        <Route path="*" element={
+          isProInstalled && dynamicRoutes.length === 0
+            ? null
+            : <Navigate to="/projects" replace />
+        } />
       </Route>
     </Routes>
   )

--- a/views/assets/src/router/routeRegistry.js
+++ b/views/assets/src/router/routeRegistry.js
@@ -1,9 +1,16 @@
 import { useState, useEffect } from 'react'
+import { matchPath, useLocation } from 'react-router-dom'
 
 /**
  * Route registry for WP Project Manager.
  * Pro plugin registers additional routes at runtime.
  * Free app picks them up reactively via useRegisteredRoutes().
+ *
+ * Route config:
+ *   { path: string, element: React.ReactElement, noSidebar?: boolean, noSubNav?: boolean }
+ *
+ * Set `noSidebar: true` on routes that should hide the AppSidebar (e.g. client-facing
+ * shortcode pages). Layout components consult this via `useIsBareLayout()`.
  */
 
 const registeredRoutes = []
@@ -13,10 +20,6 @@ function notify() {
   listeners.forEach(fn => fn())
 }
 
-/**
- * Register a route. Called by pro plugin's entry point.
- * @param {{ path: string, element: React.ReactElement }} config
- */
 export function registerRoute(config) {
   registeredRoutes.push(config)
   notify()
@@ -31,4 +34,25 @@ export function useRegisteredRoutes() {
     return () => listeners.delete(handler)
   }, [])
   return [...registeredRoutes]
+}
+
+/**
+ * Match current pathname against registered routes; return the matching config
+ * (or null). Reactive — re-runs when routes change or the URL changes.
+ */
+export function useMatchedRoute() {
+  const routes = useRegisteredRoutes()
+  const location = useLocation()
+  return routes.find(r => matchPath({ path: '/' + r.path, end: true }, location.pathname)) || null
+}
+
+/** Hook: true when the current route is registered with `noSidebar: true`. */
+export function useHideSidebar() {
+  return !!useMatchedRoute()?.noSidebar
+}
+
+/** Hook: true when the current route is registered with `noSubNav: true`. */
+export function useHideSubNav() {
+  const m = useMatchedRoute()
+  return !!(m?.noSubNav || m?.noSidebar)
 }

--- a/views/assets/src/router/routeRegistry.js
+++ b/views/assets/src/router/routeRegistry.js
@@ -9,8 +9,10 @@ import { matchPath, useLocation } from 'react-router-dom'
  * Route config:
  *   { path: string, element: React.ReactElement, noSidebar?: boolean, noSubNav?: boolean }
  *
- * Set `noSidebar: true` on routes that should hide the AppSidebar (e.g. client-facing
- * shortcode pages). Layout components consult this via `useIsBareLayout()`.
+ * Setting `noSidebar: true` on a route hides BOTH the AppSidebar and the
+ * sub-navigation (it implies `noSubNav`). Layout components consult this via
+ * `useLayoutFlags()` (single subscription, returns { hideSidebar, hideSubNav }).
+ * Thin wrappers `useHideSidebar()` / `useHideSubNav()` exist for back-compat.
  */
 
 const registeredRoutes = []
@@ -46,13 +48,25 @@ export function useMatchedRoute() {
   return routes.find(r => matchPath({ path: '/' + r.path, end: true }, location.pathname)) || null
 }
 
-/** Hook: true when the current route is registered with `noSidebar: true`. */
-export function useHideSidebar() {
-  return !!useMatchedRoute()?.noSidebar
+/**
+ * Hook: layout flags derived from the matched route's config. Single
+ * `useMatchedRoute` subscription. Setting `noSidebar: true` on a route also
+ * hides the sub-navigation.
+ */
+export function useLayoutFlags() {
+  const m = useMatchedRoute()
+  return {
+    hideSidebar: !!m?.noSidebar,
+    hideSubNav: !!(m?.noSubNav || m?.noSidebar),
+  }
 }
 
-/** Hook: true when the current route is registered with `noSubNav: true`. */
+/** Back-compat: thin wrapper. Prefer `useLayoutFlags` to avoid duplicate subs. */
+export function useHideSidebar() {
+  return useLayoutFlags().hideSidebar
+}
+
+/** Back-compat: thin wrapper. Prefer `useLayoutFlags` to avoid duplicate subs. */
 export function useHideSubNav() {
-  const m = useMatchedRoute()
-  return !!(m?.noSubNav || m?.noSidebar)
+  return useLayoutFlags().hideSubNav
 }

--- a/views/assets/src/store/projectsSlice.js
+++ b/views/assets/src/store/projectsSlice.js
@@ -165,6 +165,18 @@ export const searchUsers = createAsyncThunk(
   }
 )
 
+export const createUser = createAsyncThunk(
+  'projects/createUser',
+  async (payload, { rejectWithValue }) => {
+    try {
+      const res = await api.post('users', payload)
+      return res?.data ?? res
+    } catch (e) {
+      return rejectWithValue(e?.message || e?.data?.message || 'create_user_failed')
+    }
+  }
+)
+
 export const fetchProjectAssignees = createAsyncThunk(
   'projects/fetchProjectAssignees',
   async (projectId, { getState, rejectWithValue }) => {


### PR DESCRIPTION
- Pusher action.php: normalize notify_users (array or comma string) so frontend FormData arrays no longer crash explode().
- UserAvatar: force d=404 on gravatar URLs so blank/mp/identicon/missing defaults 404 → AvatarFallback initials render. Swap raw <img> in TopBar notifications and RichTextEditor mention list for UserAvatar.
- routeRegistry: extend route config with optional noSidebar/noSubNav flags; add useMatchedRoute/useHideSidebar/useHideSubNav hooks. App/ Frontend layouts consult these hooks instead of hardcoded paths so Pro can mark any route as bare via registerRoute.
- AppRoutes: gate catch-all Navigate("/projects") until Pro has had a chance to register at least one dynamic route, avoiding race that redirected /invoices to /projects on first paint.

Close : https://github.com/weDevsOfficial/wpuf-pro/issues/1552

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Create User dialog and in-place user creation added to project member flows.
  * New route/layout hooks allow pages to hide sidebar and sub-navigation.
  * Catch-all route now respects Pro route registration before redirecting.

* **Bug Fixes**
  * Gravatar URLs normalized so missing avatars reliably fall back to initials.
  * Notification recipient parsing made more robust.

* **Improvements**
  * Unified avatar component used across editor, notifications, and top bar.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/weDevsOfficial/wp-project-manager/pull/608?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->