### PR TITLE
feat: reintroduce promotional CTA banner + rebrand cleanup

### DIFF
--- a/views/assets/src/components/common/ProUpgradeModal.jsx
+++ b/views/assets/src/components/common/ProUpgradeModal.jsx
@@ -145,7 +145,7 @@ function ProUpgradeModal() {
                 <span style={{ color: '#ff9000', fontSize: '30px', fontWeight: 500, lineHeight: '1.6' }}>{__('Upgrade to', 'wedevs-project-manager')}</span>
               </div>
               <h2 style={{ fontSize: '30px', fontWeight: 400, lineHeight: '1.6', margin: 0, color: 'var(--pm-text-primary)' }}>
-                {__('WP Project Manager', 'wedevs-project-manager')} <span style={{ fontWeight: 700 }}>{__('Pro', 'wedevs-project-manager')}</span>
+                {__('Project Manager', 'wedevs-project-manager')} <span style={{ fontWeight: 700 }}>{__('Pro', 'wedevs-project-manager')}</span>
               </h2>
               <p style={{ fontSize: '20px', fontWeight: 400, color: 'var(--pm-text-muted)', lineHeight: '1.6', margin: 0 }}>
                 {__('unlock and take advantage of our premium features', 'wedevs-project-manager')} 🎉

--- a/views/assets/src/components/common/PromoBanner.jsx
+++ b/views/assets/src/components/common/PromoBanner.jsx
@@ -1,0 +1,200 @@
+import { __ } from '@wordpress/i18n'
+import React, { useEffect, useState, useMemo, useCallback } from 'react'
+import { X, ArrowRight } from 'lucide-react'
+
+const PROMO_URL = 'https://raw.githubusercontent.com/weDevsOfficial/wppm-util/master/promotions.json'
+const STORAGE_PREFIX = 'pm-promo-dismissed:'
+const FETCH_TIMEOUT_MS = 6000
+
+const TZ_OFFSETS = { EST: '-05:00', EDT: '-04:00', PST: '-08:00', PDT: '-07:00', UTC: '+00:00', GMT: '+00:00' }
+
+function parsePromoDate(str) {
+  if (!str) return NaN
+  const m = String(str).trim().match(/^(\d{4}-\d{2}-\d{2})[ T](\d{1,2}):(\d{2}):(\d{2})(?:\s+([A-Z]{3,4}))?$/)
+  if (!m) return Date.parse(str)
+  const [, date, h, mm, ss, tz] = m
+  const hour = h.padStart(2, '0')
+  const offset = tz && TZ_OFFSETS[tz] ? TZ_OFFSETS[tz] : '+00:00'
+  return Date.parse(`${date}T${hour}:${mm}:${ss}${offset}`)
+}
+
+function isWithinWindow(promo) {
+  if (typeof window !== 'undefined' && /[?&]pm_promo_preview=1\b/.test(window.location.search)) {
+    return true
+  }
+  const now = Date.now()
+  const start = parsePromoDate(promo.start_date)
+  const end = parsePromoDate(promo.end_date)
+  if (!Number.isNaN(start) && now < start) return false
+  if (!Number.isNaN(end) && now > end) return false
+  return true
+}
+
+function extractDiscount(text) {
+  if (!text) return null
+  const m = String(text).match(/(\d{2,3})\s*%/)
+  return m ? `${m[1]}% OFF` : null
+}
+
+function daysRemaining(endStr) {
+  const end = parsePromoDate(endStr)
+  if (Number.isNaN(end)) return null
+  const diff = Math.ceil((end - Date.now()) / 86400000)
+  return diff > 0 && diff <= 30 ? diff : null
+}
+
+export function PromoBanner({ placement = 'projects' }) {
+  const [promo, setPromo] = useState(null)
+  const [dismissed, setDismissed] = useState(false)
+
+  const dismissKey = useMemo(
+    () => (promo?.key ? `${STORAGE_PREFIX}${promo.key}` : null),
+    [promo]
+  )
+
+  useEffect(() => {
+    let cancelled = false
+    const controller = new AbortController()
+    const timer = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS)
+
+    fetch(PROMO_URL, { signal: controller.signal, cache: 'no-store' })
+      .then(r => {
+        if (!r.ok) throw new Error(`HTTP ${r.status}`)
+        return r.json()
+      })
+      .then(data => {
+        if (cancelled) return
+        if (!data || !data.key) {
+          console.warn('[PM PromoBanner] payload missing key', data)
+          return
+        }
+        if (!isWithinWindow(data)) {
+          console.info('[PM PromoBanner] promo outside window', data.key, data.start_date, data.end_date)
+          return
+        }
+        const key = `${STORAGE_PREFIX}${data.key}`
+        if (localStorage.getItem(key) === '1') {
+          setDismissed(true)
+          return
+        }
+        setPromo(data)
+      })
+      .catch(err => {
+        if (err?.name !== 'AbortError') {
+          console.warn('[PM PromoBanner] fetch failed', err)
+        }
+      })
+      .finally(() => clearTimeout(timer))
+
+    return () => {
+      cancelled = true
+      controller.abort()
+      clearTimeout(timer)
+    }
+  }, [])
+
+  const handleDismiss = useCallback(() => {
+    if (dismissKey) localStorage.setItem(dismissKey, '1')
+    setDismissed(true)
+  }, [dismissKey])
+
+  if (dismissed || !promo) return null
+
+  const action = promo.action_url
+    ? `${promo.action_url}${promo.action_url.includes('?') ? '&' : '?'}utm_content=pm-${placement}-banner`
+    : null
+
+  const discount = extractDiscount(promo.title) || extractDiscount(promo.content)
+  const daysLeft = daysRemaining(promo.end_date)
+
+  return (
+    <div
+      className="pm-promo-banner relative rounded-xl border overflow-hidden"
+      style={{
+        background: '#FAFAFB',
+        borderColor: '#E5E7EB',
+      }}
+    >
+      <span
+        aria-hidden
+        className="absolute left-0 top-0 bottom-0"
+        style={{ width: '3px', background: '#7C3AED' }}
+      />
+
+      <button
+        type="button"
+        onClick={handleDismiss}
+        aria-label={__('Dismiss', 'wedevs-project-manager')}
+        className="absolute top-2 right-2 z-20 p-1.5 rounded text-pm-text-muted hover:text-pm-text-primary bg-white/80 hover:bg-pm-hover backdrop-blur-sm transition-colors"
+      >
+        <X className="h-3.5 w-3.5" />
+      </button>
+
+      <div className="flex flex-col sm:flex-row sm:items-center gap-3 sm:gap-5 px-5 py-4 pl-6 pr-10 sm:pr-12">
+        <div className="flex items-center gap-3 flex-1 min-w-0">
+          <img
+            src={`${typeof PM_Vars !== 'undefined' ? PM_Vars.dir_url : '/wp-content/plugins/wedevs-project-manager/'}.wordpress-org/icon-128x128.gif`}
+            alt=""
+            className="shrink-0 rounded-lg"
+            style={{ height: '56px', width: '56px' }}
+          />
+          {discount && (
+            <span
+              className="shrink-0 inline-flex items-baseline gap-1 px-3 py-1.5 rounded-md"
+              style={{
+                background: 'linear-gradient(135deg, #FF8A00 0%, #FF5C00 100%)',
+                color: '#fff',
+                boxShadow: '0 4px 12px -2px rgba(255,92,0,0.45)',
+              }}
+            >
+              <span style={{ fontSize: '20px', fontWeight: 800, lineHeight: 1, letterSpacing: '-0.02em' }}>
+                {discount.replace(' OFF', '')}
+              </span>
+              <span style={{ fontSize: '11px', fontWeight: 700, letterSpacing: '0.08em' }}>
+                OFF
+              </span>
+            </span>
+          )}
+          <span className="text-sm font-semibold text-pm-text-primary truncate">
+            {promo.title}
+          </span>
+          {daysLeft != null && (
+            <span className="hidden md:inline text-[12px] text-pm-text-muted shrink-0">
+              · {daysLeft === 1
+                ? __('ends tomorrow', 'wedevs-project-manager')
+                : `${daysLeft} ${__('days left', 'wedevs-project-manager')}`}
+            </span>
+          )}
+        </div>
+
+        {action && (
+          <a
+            href={action}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="pm-promo-cta inline-flex items-center justify-center gap-2 self-start sm:self-auto shrink-0 px-5 py-2.5 rounded-md font-semibold text-[13px] tracking-[0.01em] whitespace-nowrap no-underline transition-all"
+            style={{
+              background: '#7C3AED',
+              color: '#fff',
+              boxShadow: '0 1px 2px rgba(124,58,237,0.25), 0 4px 12px -2px rgba(124,58,237,0.35)',
+              border: '1px solid #6D28D9',
+            }}
+            onMouseEnter={e => {
+              e.currentTarget.style.background = '#6D28D9'
+              e.currentTarget.style.boxShadow = '0 1px 2px rgba(124,58,237,0.3), 0 8px 18px -2px rgba(124,58,237,0.5)'
+            }}
+            onMouseLeave={e => {
+              e.currentTarget.style.background = '#7C3AED'
+              e.currentTarget.style.boxShadow = '0 1px 2px rgba(124,58,237,0.25), 0 4px 12px -2px rgba(124,58,237,0.35)'
+            }}
+          >
+            <span>{promo.action_title || __('Upgrade to Pro', 'wedevs-project-manager')}</span>
+            <ArrowRight className="h-3.5 w-3.5" />
+          </a>
+        )}
+      </div>
+    </div>
+  )
+}
+
+export default PromoBanner

--- a/views/assets/src/components/layout/TopBar.jsx
+++ b/views/assets/src/components/layout/TopBar.jsx
@@ -278,7 +278,7 @@ export function TopBar() {
 
         {/* Share Your Idea */}
         <a
-          href="https://pm.canny.io/ideas"
+          href="https://feedback.wedevs.com/b/project-manager"
           target="_blank"
           rel="noopener noreferrer"
           className="hidden md:inline-flex items-center gap-1 text-sm text-pm-text-muted hover:text-pm-accent transition-colors shrink-0"

--- a/views/assets/src/components/projects/PremiumPage.jsx
+++ b/views/assets/src/components/projects/PremiumPage.jsx
@@ -29,6 +29,7 @@ import {
   ArrowRight,
   Globe,
 } from "lucide-react";
+import { PromoBanner } from "@components/common/PromoBanner";
 
 const UPGRADE_URL =
   "https://wedevs.com/wp-project-manager-pro/pricing/?utm_source=wpdashboard&utm_medium=premium-page";
@@ -138,9 +139,14 @@ export default function PremiumPage() {
 
   return (
     <div className="max-w-[1400px] mx-auto p-4 sm:p-6 space-y-8">
+      <PromoBanner placement="premium" />
+
       {/* ── Hero Banner ── */}
-      <div className="relative rounded-2xl overflow-hidden bg-gradient-to-br from-purple-600 via-indigo-600 to-blue-600 px-8 py-10 md:px-12 md:py-14 text-center text-white">
-        <div className="absolute inset-0 bg-[radial-gradient(circle_at_30%_50%,rgba(255,255,255,0.1),transparent_70%)]" />
+      <div
+        className="relative rounded-2xl overflow-hidden px-8 py-10 md:px-12 md:py-14 text-center text-white"
+        style={{ background: 'linear-gradient(135deg, #7C3AED 0%, #4F46E5 50%, #2563EB 100%)' }}
+      >
+        <div className="absolute inset-0" style={{ background: 'radial-gradient(circle at 30% 50%, rgba(255,255,255,0.12), transparent 70%)' }} />
         <div className="relative z-10">
           <span className="inline-flex items-center gap-1.5 bg-white/20 backdrop-blur-sm text-white text-sm font-medium px-3 py-1 rounded-full mb-3">
             <Sparkles className="h-4 w-4" />

--- a/views/assets/src/components/projects/ProjectsPage/index.jsx
+++ b/views/assets/src/components/projects/ProjectsPage/index.jsx
@@ -91,6 +91,7 @@ import {
 
 import AiCreateDialog from "../AiCreateDialog";
 import { ProjectCreateSheet } from "../ProjectCreateSheet";
+import { PromoBanner } from "@components/common/PromoBanner";
 
 import { formatPmDate } from "@lib/pm-utils";
 import {
@@ -693,6 +694,8 @@ export default function ProjectsPage() {
 
   return (
     <div className="max-w-[1400px] mx-auto p-4 sm:p-6 space-y-6">
+      <PromoBanner placement="projects" />
+
       <div className="flex items-center justify-between flex-wrap gap-2">
         <h1 className="text-2xl font-bold text-pm-text-primary">
           {__("Projects", 'wedevs-project-manager')}


### PR DESCRIPTION
Adds PromoBanner React component that fetches promotional offers from weDevsOfficial/wppm-util/promotions.json and renders an editorial-style banner on /projects and /premium pages. Respects start/end date window (with timezone-aware parser supporting EST/EDT/PST/PDT/UTC/GMT suffixes) and offers per-promo dismiss via localStorage. Hidden expired-promo testing via ?pm_promo_preview=1 query flag.

Other changes:
- TopBar "Share your idea" link now points to feedback.wedevs.com/b/project-manager (replaces pm.canny.io/ideas).
- ProUpgradeModal title now reads "Project Manager Pro" (drops "WP" prefix).
- PremiumPage hero gradient switched to inline linear-gradient to bypass Tailwind --tw-gradient-stops chain fragility under important:true config (was rendering invisible in light mode).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Promotional banners now display on Projects and Premium pages with discount details and countdown timers.
  * Users can dismiss banners; dismissals are remembered per promotion.

* **Updates**
  * Modal header text updated for improved clarity.
  * "Share Your Idea" feedback link destination updated.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/weDevsOfficial/wp-project-manager/pull/609?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->