### PR TITLE
fix: upgrade notice persists after running update

### DIFF
--- a/core/Upgrades/Upgrade.php
+++ b/core/Upgrades/Upgrade.php
@@ -226,8 +226,8 @@ class Upgrade {
             }
         }
 
+        update_option( 'pm_db_version', wedevs_pm_config('app.db_version') );
         delete_option( 'cpm_db_version' );
-       // update_option( 'pm_db_version', '2.0-beta' );
     }
 }
 


### PR DESCRIPTION
## Summary

- `perform_updates()` only stamped `pm_db_version` up to `'2.5'` (last key in `$updates` array) but `config/app.php` has `db_version = '2.5.1'`
- After clicking "Run the Update", `is_needs_update()` compared `'2.5' < '2.5.1'` → `true` → notice never dismissed
- Fix: stamp `pm_db_version` to `wedevs_pm_config('app.db_version')` after all upgrades complete

## Test plan

- [ ] Set `pm_db_version` to any value < `2.5.1` (e.g. via WP CLI: `wp option update pm_db_version 2.4`)
- [ ] Visit WP Admin → confirm "WP Project Manager Data Update Required" notice appears
- [ ] Click "Run the Update" → accept confirmation dialog
- [ ] Verify notice is gone after page reloads
- [ ] Confirm `wp option get pm_db_version` returns `2.5.1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced the database upgrade process to properly track the current version and clean up legacy version data during updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->