### PR TITLE
fix: Task Lists UI inconsistencies + comment notification link

### DIFF
--- a/core/Notifications/Emails/Update_Comment_Notification.php
+++ b/core/Notifications/Emails/Update_Comment_Notification.php
@@ -61,7 +61,7 @@ class Update_Comment_Notification extends Email {
             $comment_link = $this->pm_link() . '#/projects/'.$project->id.'/task-lists/'.$request['commentable_id'];
         }else{
             $type        = __( 'Task', 'wedevs-project-manager' );
-            $comment_link = $this->pm_link() . '#projects/'.$project->id. '/task-lists/tasks/' . $request['commentable_id'];
+            $comment_link = $this->pm_link() . '#/projects/'.$project->id. '/task-lists/tasks/' . $request['commentable_id'];
         }
 
         

--- a/views/assets/src/components/tasks/TaskDetailSheet/index.jsx
+++ b/views/assets/src/components/tasks/TaskDetailSheet/index.jsx
@@ -161,13 +161,13 @@ export default function TaskDetailSheet() {
         const restore = prePathRef.current
         prePathRef.current = null
         lastPushedPathRef.current = null
-        navigate(restore, { replace: false })
+        navigate(restore, { replace: true })
       } else if (lastPushedPathRef.current && isOnTaskUrl) {
         let fallback = location.pathname.replace(/\/tasks\/\d+$/, '')
         const sprintProjectMatch = fallback.match(/^\/sprints\/projects\/\d+$/)
         if (sprintProjectMatch) fallback = '/sprints'
         lastPushedPathRef.current = null
-        navigate(fallback, { replace: false })
+        navigate(fallback, { replace: true })
       } else {
         prePathRef.current = null
         lastPushedPathRef.current = null
@@ -217,7 +217,7 @@ export default function TaskDetailSheet() {
       prePathRef.current = location.pathname + location.search
     }
     lastPushedPathRef.current = target
-    navigate(target, { replace: false })
+    navigate(target, { replace: true })
   }, [taskSheetOpen, currentTask?.id, currentTask?.task_list_id, projectId, location.pathname, location.search, navigate, dispatch])
 
 

--- a/views/assets/src/components/tasks/TaskListSection.jsx
+++ b/views/assets/src/components/tasks/TaskListSection.jsx
@@ -64,6 +64,8 @@ export default function TaskListSection({ list, projectId, showLabels, isInbox =
   const [newDesc, setNewDesc] = useState('')
   const [newDueDate, setNewDueDate] = useState('')
   const [assigneeSearch, setAssigneeSearch] = useState('')
+  const [assigneeOpen, setAssigneeOpen] = useState(false)
+  const assigneeBoxRef = useRef(null)
   const projectMembers = project?.assignees?.data ?? []
   const assigneeResults = assigneeSearch.trim().length === 0
     ? projectMembers
@@ -84,6 +86,7 @@ export default function TaskListSection({ list, projectId, showLabels, isInbox =
 
   const handleSearchUsers = useCallback((q) => {
     setAssigneeSearch(q)
+    setAssigneeOpen(true)
   }, [])
 
   const addAssignee = useCallback((user) => {
@@ -96,6 +99,15 @@ export default function TaskListSection({ list, projectId, showLabels, isInbox =
   const removeAssignee = useCallback((userId) => {
     setSelectedAssignees(prev => prev.filter(u => u.id !== userId))
   }, [])
+
+  useEffect(() => {
+    if (!assigneeOpen) return
+    const onDown = (e) => {
+      if (assigneeBoxRef.current && !assigneeBoxRef.current.contains(e.target)) setAssigneeOpen(false)
+    }
+    document.addEventListener('mousedown', onDown)
+    return () => document.removeEventListener('mousedown', onDown)
+  }, [assigneeOpen])
 
   useEffect(() => {
     if (!showNewTask || !projectId || milestones.length > 0) return;
@@ -111,6 +123,7 @@ export default function TaskListSection({ list, projectId, showLabels, isInbox =
     setNewDesc('')
     setNewDueDate('')
     setAssigneeSearch('')
+    setAssigneeOpen(false)
     setSelectedAssignees([])
     setSelectedMilestone('')
   }, [])
@@ -534,14 +547,16 @@ export default function TaskListSection({ list, projectId, showLabels, isInbox =
                   <div className="space-y-1.5">
                     <div className="flex items-center gap-2">
                       <label className="text-sm text-pm-text-muted w-16 shrink-0">{__('Assign', 'wedevs-project-manager')}</label>
-                      <div className="relative flex-1">
+                      <div className="relative flex-1" ref={assigneeBoxRef}>
                         <Input
                           value={assigneeSearch}
                           onChange={e => handleSearchUsers(e.target.value)}
+                          onFocus={() => setAssigneeOpen(true)}
+                          onKeyDown={e => { if (e.key === 'Escape') setAssigneeOpen(false) }}
                           placeholder={__('Search users...', 'wedevs-project-manager')}
                           className="h-8 text-sm"
                         />
-                        {assigneeResults.length > 0 && (
+                        {assigneeOpen && assigneeResults.length > 0 && (
                           <div className="absolute top-full left-0 right-0 mt-1 bg-background border rounded-lg shadow-lg z-50 max-h-40 overflow-y-auto">
                             {assigneeResults.map(user => {
                               const isSelected = selectedAssignees.some(u => parseInt(u.id) === parseInt(user.id))

--- a/views/assets/src/components/tasks/TaskListsPage.jsx
+++ b/views/assets/src/components/tasks/TaskListsPage.jsx
@@ -209,7 +209,7 @@ export default function TaskListsPage() {
           </h1>
           {lists.length > 0 && (
             <span className="text-sm text-pm-text-muted bg-muted/60 px-2 py-0.5 rounded-full tabular-nums">
-              {lists.length} {lists.length === 1 ? __("list", 'wedevs-project-manager') : __("lists", 'wedevs-project-manager')}
+              {lists.length}
             </span>
           )}
         </div>


### PR DESCRIPTION
Addresses bugs 1–3 and the update-comment link from weDevsOfficial/pm-pro#351 (Silk Media client report). The duplicate-email fix lives in the Pro repo; the "Link to Backend" email-link behaviour (bug 4) is the existing `link_to_backend` setting, not a code change.

### Changes
1. **Task Lists count format** — render a bare count instead of `1 list`/`2 lists`, matching Files/Discussions. `TaskListsPage.jsx`
2. **Add-task assignee dropdown stuck** — added an explicit open flag (open on focus/typing, close on select, outside-click and Escape). Previously it had no close mechanism and covered the Add Task button until refresh. `TaskListSection.jsx`
3. **Back button opened the edit sheet** — the task sheet now uses history `replace` instead of `push`, so Back after completing a task returns to the previous page. `TaskDetailSheet/index.jsx`
4. **Update-comment email link** — fixed `#projects/...` → `#/projects/...` so the hash route matches. `Update_Comment_Notification.php`

### Notes
- Source only; `views/assets/dist/` is gitignored and rebuilt by CI/release.
- Milestones use a Redux dialog (not routing) so they are unaffected by change 3.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved task detail sheet navigation and browser history handling.
  * Enhanced assignee dropdown to properly close when clicking outside the field.
  * Updated comment notification link format for consistency.

* **UI Changes**
  * Simplified task list count badge to display only the numeric value.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->