### PR TITLE
Keep PHP 8.1–8.5 deprecation notices out of REST JSON

### DIFF
--- a/composer-scripts/patch-deprecations.php
+++ b/composer-scripts/patch-deprecations.php
@@ -132,8 +132,48 @@ function patchReturnType($file, $method) {
 }
 
 
+function patchArrQuery($file) {
+    if (!file_exists($file)) {
+        echo "❌ File not found: $file\n";
+        return;
+    }
+
+    $content = file_get_contents($file);
+
+    if (strpos($content, "http_build_query(\$array, '',") !== false) {
+        echo "⚠️ Arr::query already patched or no changes needed\n";
+        return;
+    }
+
+    $content = preg_replace(
+        '/http_build_query\(\$array,\s*null,\s*/',
+        "http_build_query(\$array, '', ",
+        $content,
+        1,
+        $replacements
+    );
+
+    if ($replacements !== 1) {
+        echo "❌ Could not patch Arr::query signature (pattern not found)\n";
+        return;
+    }
+
+    if (file_put_contents($file, $content) === false) {
+        echo "❌ Failed to write patched Arr.php\n";
+        return;
+    }
+
+    echo "✅ Patched Arr::query: null \$numeric_prefix -> '' (PHP 8.1+ deprecation)\n";
+}
+
+
+// Patch Arr::query null numeric_prefix deprecation (PHP 8.1–8.4)
+// display_errors-on environments otherwise leak a Deprecated notice into JSON.
+echo "=== Patching Illuminate Support Arr ===\n";
+patchArrQuery(__DIR__ . '/../vendor/illuminate/support/Arr.php');
+
 // Patch Container class for PSR-11 and ArrayAccess compatibility
-echo "=== Patching Illuminate Container ===\n";
+echo "\n=== Patching Illuminate Container ===\n";
 $targetContainerFile = __DIR__ . '/../vendor/illuminate/container/Container.php';
 patchContainerPSR11($targetContainerFile);
 

--- a/composer-scripts/patch-deprecations.php
+++ b/composer-scripts/patch-deprecations.php
@@ -135,14 +135,14 @@ function patchReturnType($file, $method) {
 function patchArrQuery($file) {
     if (!file_exists($file)) {
         echo "❌ File not found: $file\n";
-        return;
+        return false;
     }
 
     $content = file_get_contents($file);
 
     if (strpos($content, "http_build_query(\$array, '',") !== false) {
         echo "⚠️ Arr::query already patched or no changes needed\n";
-        return;
+        return true;
     }
 
     $content = preg_replace(
@@ -155,22 +155,26 @@ function patchArrQuery($file) {
 
     if ($replacements !== 1) {
         echo "❌ Could not patch Arr::query signature (pattern not found)\n";
-        return;
+        return false;
     }
 
     if (file_put_contents($file, $content) === false) {
         echo "❌ Failed to write patched Arr.php\n";
-        return;
+        return false;
     }
 
     echo "✅ Patched Arr::query: null \$numeric_prefix -> '' (PHP 8.1+ deprecation)\n";
+    return true;
 }
 
 
 // Patch Arr::query null numeric_prefix deprecation (PHP 8.1–8.4)
 // display_errors-on environments otherwise leak a Deprecated notice into JSON.
 echo "=== Patching Illuminate Support Arr ===\n";
-patchArrQuery(__DIR__ . '/../vendor/illuminate/support/Arr.php');
+if (! patchArrQuery(__DIR__ . '/../vendor/illuminate/support/Arr.php')) {
+    fwrite(STDERR, "❌ Arr::query deprecation patch failed — aborting so the build does not ship unpatched vendor code.\n");
+    exit(1);
+}
 
 // Patch Container class for PSR-11 and ArrayAccess compatibility
 echo "\n=== Patching Illuminate Container ===\n";

--- a/core/Router/WP_Router.php
+++ b/core/Router/WP_Router.php
@@ -29,6 +29,42 @@ class WP_Router {
 		static::$routes = $routes;
 
         add_action( 'rest_api_init', array( new WP_Router, 'make_wp_rest_route' ) );
+
+        // Keep PHP notices/deprecations (incl. PHP 8.1–8.5 ones from vendor libs)
+        // out of the JSON body — they would otherwise corrupt REST responses when
+        // display_errors is on. Errors are still logged; only display is silenced.
+        add_filter( 'rest_pre_dispatch', array( __CLASS__, 'silence_error_display' ), 10, 3 );
+	}
+
+	/**
+	 * Disable error display for this plugin's REST requests so stray PHP
+	 * notices/deprecations never leak into the JSON response body.
+	 *
+	 * @param  mixed            $result
+	 * @param  \WP_REST_Server  $server
+	 * @param  \WP_REST_Request $request
+	 *
+	 * @return mixed
+	 */
+	public static function silence_error_display( $result, $server, $request ) {
+		if ( ! is_object( $request ) ) {
+			return $result;
+		}
+
+		$namespace = wedevs_pm_api_namespace();
+		$route     = ltrim( (string) $request->get_route(), '/' );
+
+		// Exact namespace or a sub-route of it — avoids matching unrelated prefixes (pm/v2 vs pm/v20).
+		if ( $route === $namespace || strpos( $route, $namespace . '/' ) === 0 ) {
+			static $logged = false;
+
+			if ( ini_set( 'display_errors', '0' ) === false && ! $logged ) {
+				$logged = true;
+				error_log( 'WeDevs PM: unable to disable display_errors for REST request; PHP notices may leak into JSON responses.' );
+			}
+		}
+
+		return $result;
 	}
 
 	/**

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "build": "wp-scripts build",
     "lint": "eslint views/assets/src --ext .ts,.tsx",
     "makepot": "wp i18n make-pot . languages/wedevs-project-manager.pot --exclude=node_modules,build,tests,views/assets/dist,vendor",
-    "release": "grunt release --force"
+    "release": "php composer-scripts/patch-deprecations.php && grunt release --force"
   },
   "dependencies": {
     "@babel/runtime": "^7.24.0",


### PR DESCRIPTION
## Problem

On PHP 8.1+, `Illuminate\Support\Arr::query()` passes `null` as `http_build_query()`'s `$numeric_prefix` (a `string`), which is deprecated. With `display_errors` on, the `Deprecated` notice is printed **before** the JSON body and corrupts the REST response — e.g. the projects list renders **empty despite data existing**.

```
Deprecated: http_build_query(): Passing null to parameter #2 ($numeric_prefix) of type string is deprecated in .../illuminate/support/Arr.php on line 599
{ "data": [ ... ] }
```

## Fix

1. **Patch the vendor deprecation at source** — add an idempotent `patchArrQuery()` to `composer-scripts/patch-deprecations.php` (`null` → `''`, behaviour-identical on every PHP 8.x incl. **8.5**). Runs automatically on composer `post-install`/`post-update`.
2. **Run the patcher on `npm run release`** — release builds ship the patched vendor even when composer's post-install hasn't run.
3. **Harden the REST router** — silence error *display* (logging untouched) for this plugin's `pm/v*` requests via `rest_pre_dispatch`. Belt-and-suspenders: any current **or future (8.5+)** notice/deprecation from any vendor lib can never leak into the JSON body.

## Scope

Environmental/PHP-version bug, independent of any feature work. 3 files, +56/−2.

## Test

- PHP 8.1–8.5 with `display_errors=on`: `GET /wp-json/pm/v2/advanced/projects?...&orderby=id:desc` returns clean JSON; projects list populates.
- `php composer-scripts/patch-deprecations.php` is idempotent (re-run reports "already patched").

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed additional PHP 8.1–8.4 deprecation warnings that could corrupt REST API responses.
  * Silenced on-screen PHP error display for REST requests under the plugin’s API namespace to prevent noisy output in responses.
* **Chores**
  * Updated the release process to run the deprecation patch step before the Grunt release command.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->