### PR TITLE
fix(permissions): hide UI actions when the user lacks the capability

### DIFF
--- a/views/assets/src/components/projects/FilesPage/index.jsx
+++ b/views/assets/src/components/projects/FilesPage/index.jsx
@@ -50,8 +50,10 @@ export default function FilesPage() {
   const [ConfirmDialog, confirm] = useConfirm();
   const project = useCurrentProject(projectId);
   const { isPro, userCan, isManager, currentUserId } = usePermissions(project);
+  // No delete_file capability exists — file delete is manager-or-creator (Vue
+  // can_edit_file parity). The bogus userCan('delete_file') always returned false.
   const canDeleteFile = (f) => {
-    if (isManager || userCan('delete_file')) return true;
+    if (isManager) return true;
     const creatorId = f?.creator?.data?.id ?? f?.created_by;
     return currentUserId && creatorId && String(currentUserId) === String(creatorId);
   };

--- a/views/assets/src/components/projects/FilesPage/index.jsx
+++ b/views/assets/src/components/projects/FilesPage/index.jsx
@@ -54,7 +54,7 @@ export default function FilesPage() {
   // can_edit_file parity). The bogus userCan('delete_file') always returned false.
   const canDeleteFile = (f) => {
     if (isManager) return true;
-    const creatorId = f?.creator?.data?.id ?? f?.created_by;
+    const creatorId = f?.creator?.data?.id ?? f?.created_by ?? f?.creator?.id;
     return currentUserId && creatorId && String(currentUserId) === String(creatorId);
   };
   const { setOpen: setProModalOpen } = useProModal();

--- a/views/assets/src/components/projects/MilestonesPage/parts/MilestoneCard.jsx
+++ b/views/assets/src/components/projects/MilestonesPage/parts/MilestoneCard.jsx
@@ -52,7 +52,7 @@ export default function MilestoneCard({ milestone, projectId, onEdit, onImportTa
   // No edit_milestone/delete_milestone capability exists — milestone edit/delete
   // is manager-or-creator (Vue can_edit_milestone parity). The bogus userCan keys
   // always returned false.
-  const creatorId = milestone?.creator?.data?.id ?? milestone?.created_by;
+  const creatorId = milestone?.creator?.data?.id ?? milestone?.created_by ?? milestone?.creator?.id;
   const canEditMilestone =
     isManager ||
     (currentUserId && creatorId && String(currentUserId) === String(creatorId));
@@ -138,7 +138,7 @@ export default function MilestoneCard({ milestone, projectId, onEdit, onImportTa
     } catch {
       toast.error(__("Failed to update status", 'wedevs-project-manager'));
     }
-  }, [dispatch, projectId, milestone, isComplete, toast, __]);
+  }, [dispatch, projectId, milestone, isComplete, toast, __, canEditMilestone]);
 
   const handleTogglePrivacy = useCallback(async () => {
     const newPrivacy = milestone.meta?.privacy ? 0 : 1;

--- a/views/assets/src/components/projects/MilestonesPage/parts/MilestoneCard.jsx
+++ b/views/assets/src/components/projects/MilestonesPage/parts/MilestoneCard.jsx
@@ -119,6 +119,7 @@ export default function MilestoneCard({ milestone, projectId, onEdit, onImportTa
   }, [dispatch, projectId, milestone.id, toast, __]);
 
   const handleToggleStatus = useCallback(async () => {
+    if (!canEditMilestone) return;
     const newStatus = isComplete ? "incomplete" : "complete";
     try {
       await dispatch(
@@ -163,7 +164,8 @@ export default function MilestoneCard({ milestone, projectId, onEdit, onImportTa
           <button
             type="button"
             onClick={handleToggleStatus}
-            className="shrink-0 mt-0.5"
+            disabled={!canEditMilestone}
+            className={cn("shrink-0 mt-0.5", !canEditMilestone && "cursor-default")}
             title={isComplete ? __("Mark Incomplete", 'wedevs-project-manager') : __("Mark Complete", 'wedevs-project-manager')}
           >
             <CheckCircle

--- a/views/assets/src/components/projects/MilestonesPage/parts/MilestoneCard.jsx
+++ b/views/assets/src/components/projects/MilestonesPage/parts/MilestoneCard.jsx
@@ -49,12 +49,14 @@ export default function MilestoneCard({ milestone, projectId, onEdit, onImportTa
   const navigate = useNavigate();
   const project = useCurrentProject(projectId);
   const { isPro, userCan, isManager, currentUserId } = usePermissions(project);
+  // No edit_milestone/delete_milestone capability exists — milestone edit/delete
+  // is manager-or-creator (Vue can_edit_milestone parity). The bogus userCan keys
+  // always returned false.
   const creatorId = milestone?.creator?.data?.id ?? milestone?.created_by;
   const canEditMilestone =
     isManager ||
-    userCan('edit_milestone') ||
     (currentUserId && creatorId && String(currentUserId) === String(creatorId));
-  const canDeleteMilestone = isManager || userCan('delete_milestone') || canEditMilestone;
+  const canDeleteMilestone = canEditMilestone;
 
   const isComplete =
     milestone.status === "complete" || milestone.status === 1 || milestone.status === "1";

--- a/views/assets/src/components/projects/ProjectsPage/index.jsx
+++ b/views/assets/src/components/projects/ProjectsPage/index.jsx
@@ -19,7 +19,7 @@ import {
 } from "@store/projectsSlice";
 import { cn } from "@lib/utils";
 import { useToast } from "@hooks/useToast";
-import { usePermissions } from "@hooks/usePermissions";
+import { usePermissions, pmIsManager } from "@hooks/usePermissions";
 import { useProApi } from "@hooks/useProApi";
 import { useProModal } from "@components/common/ProUpgradeModal";
 
@@ -332,7 +332,13 @@ export default function ProjectsPage() {
     );
   };
 
-  const renderProjectDropdown = (project) => (
+  const renderProjectDropdown = (project) => {
+    // Project-level actions (edit/complete/settings/duplicate/delete) are
+    // manager-only — mirrors Vue `v-if="is_manager(project)"`. manage_options /
+    // manager cap bypass via pmIsManager.
+    if (!pmIsManager(project)) return null;
+
+    return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
         <Button variant="ghost" size="icon" className="h-8 w-8 text-pm-text-primary">
@@ -376,7 +382,8 @@ export default function ProjectsPage() {
         </DropdownMenuItem>
       </DropdownMenuContent>
     </DropdownMenu>
-  );
+    );
+  };
 
   const renderGridView = () => (
     <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-5">
@@ -700,25 +707,27 @@ export default function ProjectsPage() {
         <h1 className="text-2xl font-bold text-pm-text-primary">
           {__("Projects", 'wedevs-project-manager')}
         </h1>
-        <div className="flex items-center gap-2">
-          <Button
-            size="sm"
-            variant="outline"
-            className="gap-1.5"
-            onClick={() => setAiDialogOpen(true)}
-          >
-            <Sparkles className="h-5 w-5" />
-            {__("AI Create", 'wedevs-project-manager')}
-          </Button>
-          <Button
-            size="sm"
-            className="gap-1.5"
-            onClick={() => dispatch(setCreateSheetOpen(true))}
-          >
-            <Plus className="h-5 w-5" />
-            {__("New Project", 'wedevs-project-manager')}
-          </Button>
-        </div>
+        {canCreate && (
+          <div className="flex items-center gap-2">
+            <Button
+              size="sm"
+              variant="outline"
+              className="gap-1.5"
+              onClick={() => setAiDialogOpen(true)}
+            >
+              <Sparkles className="h-5 w-5" />
+              {__("AI Create", 'wedevs-project-manager')}
+            </Button>
+            <Button
+              size="sm"
+              className="gap-1.5"
+              onClick={() => dispatch(setCreateSheetOpen(true))}
+            >
+              <Plus className="h-5 w-5" />
+              {__("New Project", 'wedevs-project-manager')}
+            </Button>
+          </div>
+        )}
       </div>
 
       <div className="flex items-center justify-between flex-wrap gap-3">

--- a/views/assets/src/components/tasks/TaskDetailSheet/index.jsx
+++ b/views/assets/src/components/tasks/TaskDetailSheet/index.jsx
@@ -635,7 +635,7 @@ export default function TaskDetailSheet() {
                       <Button variant="ghost" size="sm" className="h-6 text-[15px] px-2" onClick={() => setEditingDates(false)}>{__('Cancel', 'wedevs-project-manager')}</Button>
                     </div>
                   ) : (
-                    <button type="button" onClick={() => setEditingDates(true)} className="text-sm text-pm-text-primary hover:text-pm-accent transition-colors">
+                    <button type="button" disabled={!canEditTask(currentTask)} onClick={() => canEditTask(currentTask) && setEditingDates(true)} className={cn('text-sm text-pm-text-primary transition-colors', canEditTask(currentTask) && 'hover:text-pm-accent')}>
                       {extractDateStr(currentTask.start_at) && extractDateStr(currentTask.due_date)
                         ? `${formatPmDate(currentTask.start_at)} → ${formatPmDate(currentTask.due_date)}`
                         : extractDateStr(currentTask.due_date)
@@ -655,17 +655,21 @@ export default function TaskDetailSheet() {
                         <span key={user.id || user.assigned_to} className="inline-flex items-center gap-1 text-sm bg-muted/50 rounded-full pl-0.5 pr-2 py-0.5">
                           <UserAvatar user={user} size="sm" />
                           {user.display_name}
-                          <button type="button" className="ml-0.5 text-pm-text-muted hover:text-destructive" onClick={() => handleRemoveAssignee(user.assigned_to ?? user.id)}>
-                            <X className="h-3.5 w-3.5" />
-                          </button>
+                          {canEditTask(currentTask) && (
+                            <button type="button" className="ml-0.5 text-pm-text-muted hover:text-destructive" onClick={() => handleRemoveAssignee(user.assigned_to ?? user.id)}>
+                              <X className="h-3.5 w-3.5" />
+                            </button>
+                          )}
                         </span>
                       ))}
-                      <button type="button" onClick={() => setShowAssigneeSearch(v => !v)}
-                        className="inline-flex items-center gap-1 text-[15px] text-pm-accent hover:text-pm-accent/80 transition-colors">
-                        <Plus className="h-3.5 w-3.5" />{__('Add', 'wedevs-project-manager')}
-                      </button>
+                      {canEditTask(currentTask) && (
+                        <button type="button" onClick={() => setShowAssigneeSearch(v => !v)}
+                          className="inline-flex items-center gap-1 text-[15px] text-pm-accent hover:text-pm-accent/80 transition-colors">
+                          <Plus className="h-3.5 w-3.5" />{__('Add', 'wedevs-project-manager')}
+                        </button>
+                      )}
                     </div>
-                    {showAssigneeSearch && (
+                    {canEditTask(currentTask) && showAssigneeSearch && (
                       <div className="relative mt-1.5">
                         <Input autoFocus value={assigneeQuery} onChange={e => setAssigneeQuery(e.target.value)}
                           placeholder={__('Search members...', 'wedevs-project-manager')} className="h-7 text-sm"
@@ -696,9 +700,9 @@ export default function TaskDetailSheet() {
 
                 <TaskEstimationField task={currentTask} projectId={currentTask?.project_id} dispatch={dispatch} api={api} />
 
-                <TaskTypeField task={currentTask} projectId={currentTask?.project_id} dispatch={dispatch} api={api} />
+                <TaskTypeField task={currentTask} projectId={currentTask?.project_id} dispatch={dispatch} api={api} canEdit={canEditTask(currentTask)} />
 
-                <MilestoneField task={currentTask} projectId={currentTask?.project_id} api={api} />
+                <MilestoneField task={currentTask} projectId={currentTask?.project_id} api={api} canEdit={canEditTask(currentTask)} />
 
                 {canEditTask(currentTask) && userCan('view_private_task') && (
                   <TaskPrivacyField task={currentTask} projectId={currentTask?.project_id} dispatch={dispatch} api={api} />

--- a/views/assets/src/components/tasks/TaskDetailSheet/index.jsx
+++ b/views/assets/src/components/tasks/TaskDetailSheet/index.jsx
@@ -104,6 +104,7 @@ export default function TaskDetailSheet() {
   const isProContext = !storeProjectId && (currentTask?.project_id || currentTask?.project?.id)
   const project = useCurrentProject(projectId)
   const { canEditTask, canEditComment, userCan } = usePermissions(project)
+  const canEditCurrentTask = currentTask ? canEditTask(currentTask) : false
 
   const [editingTitle, setEditingTitle] = useState(false)
   const [title, setTitle] = useState('')
@@ -283,7 +284,7 @@ export default function TaskDetailSheet() {
   }, [dispatch, projectId, currentTask, toast, __])
 
   const handleDateSave = useCallback(async () => {
-    if (!currentTask || !projectId) return
+    if (!currentTask || !projectId || !canEditCurrentTask) return
     try {
       await dispatch(updateTask({
         projectId, taskId: currentTask.id,
@@ -294,7 +295,11 @@ export default function TaskDetailSheet() {
     } catch {
       toast.error(__('Failed to update dates', 'wedevs-project-manager'))
     }
-  }, [dispatch, projectId, currentTask, startDate, dueDate, toast, __])
+  }, [dispatch, projectId, currentTask, startDate, dueDate, toast, __, canEditCurrentTask])
+
+  useEffect(() => {
+    if (!canEditCurrentTask) setEditingDates(false)
+  }, [canEditCurrentTask, currentTask?.id])
 
   const projectMembers = project?.assignees?.data ?? []
   const filteredMembers = assigneeQuery.trim().length === 0
@@ -635,7 +640,7 @@ export default function TaskDetailSheet() {
                       <Button variant="ghost" size="sm" className="h-6 text-[15px] px-2" onClick={() => setEditingDates(false)}>{__('Cancel', 'wedevs-project-manager')}</Button>
                     </div>
                   ) : (
-                    <button type="button" disabled={!canEditTask(currentTask)} onClick={() => canEditTask(currentTask) && setEditingDates(true)} className={cn('text-sm text-pm-text-primary transition-colors', canEditTask(currentTask) && 'hover:text-pm-accent')}>
+                    <button type="button" disabled={!canEditCurrentTask} onClick={() => canEditCurrentTask && setEditingDates(true)} className={cn('text-sm text-pm-text-primary transition-colors', canEditCurrentTask && 'hover:text-pm-accent')}>
                       {extractDateStr(currentTask.start_at) && extractDateStr(currentTask.due_date)
                         ? `${formatPmDate(currentTask.start_at)} → ${formatPmDate(currentTask.due_date)}`
                         : extractDateStr(currentTask.due_date)

--- a/views/assets/src/components/tasks/TaskDetailSheet/parts/fields/MilestoneField.jsx
+++ b/views/assets/src/components/tasks/TaskDetailSheet/parts/fields/MilestoneField.jsx
@@ -7,7 +7,7 @@ import { markTaskModified } from '@store/tasksSlice';
 import { removeTaskFromMilestone, addTaskToMilestone } from '@store/milestonesSlice';
 import { Milestone as MilestoneIcon, ChevronDown, X, Check } from 'lucide-react';
 
-export default function MilestoneField({ task, projectId, api }) {
+export default function MilestoneField({ task, projectId, api, canEdit = true }) {
   const toast = useToast();
   const dispatch = useAppDispatch();
   const [milestones, setMilestones] = useState([]);
@@ -112,19 +112,19 @@ export default function MilestoneField({ task, projectId, api }) {
       <div className="relative flex items-center gap-1 h-full" ref={dropdownRef}>
         <button
           type="button"
-          disabled={saving}
+          disabled={saving || !canEdit}
           onClick={() => setOpen(v => !v)}
           className={cn(
             'flex items-center gap-1 text-sm transition-colors',
             currentMilestone ? 'text-pm-text-primary' : 'text-pm-text-muted',
-            'hover:text-pm-accent disabled:opacity-50'
+            canEdit && 'hover:text-pm-accent disabled:opacity-50'
           )}
         >
           <span>{saving ? __('Saving...', 'wedevs-project-manager') : (currentMilestone?.title || __('None', 'wedevs-project-manager'))}</span>
-          <ChevronDown className="h-3.5 w-3.5 shrink-0 opacity-60" />
+          {canEdit && <ChevronDown className="h-3.5 w-3.5 shrink-0 opacity-60" />}
         </button>
 
-        {currentMilestone && !saving && (
+        {canEdit && currentMilestone && !saving && (
           <button
             type="button"
             onClick={(e) => { e.stopPropagation(); handleSelect(null); }}

--- a/views/assets/src/components/tasks/TaskDetailSheet/parts/fields/MilestoneField.jsx
+++ b/views/assets/src/components/tasks/TaskDetailSheet/parts/fields/MilestoneField.jsx
@@ -48,6 +48,10 @@ export default function MilestoneField({ task, projectId, api, canEdit = true })
     setMilestones([]);
   }, [taskId]);
 
+  useEffect(() => {
+    if (!canEdit) setOpen(false);
+  }, [canEdit, taskId]);
+
   // Close on outside click
   useEffect(() => {
     if (!open) return;
@@ -61,7 +65,7 @@ export default function MilestoneField({ task, projectId, api, canEdit = true })
   }, [open]);
 
   const handleSelect = async (milestone) => {
-    if (saving || !taskId || !projectId) return;
+    if (!canEdit || saving || !taskId || !projectId) return;
     setOpen(false);
 
     if (milestone?.id === currentMilestone?.id) return;
@@ -135,7 +139,7 @@ export default function MilestoneField({ task, projectId, api, canEdit = true })
           </button>
         )}
 
-        {open && (
+        {canEdit && open && (
           <div className="absolute left-0 top-full mt-1 z-50 bg-background border rounded-lg shadow-lg min-w-[200px] max-h-48 overflow-y-auto">
             <button
               type="button"

--- a/views/assets/src/components/tasks/TaskDetailSheet/parts/fields/TaskTypeField.jsx
+++ b/views/assets/src/components/tasks/TaskDetailSheet/parts/fields/TaskTypeField.jsx
@@ -9,7 +9,7 @@ import {
 } from '@components/ui/popover';
 import { Check, ListTodo, X } from 'lucide-react';
 
-export default function TaskTypeField({ task, projectId, dispatch, api }) {
+export default function TaskTypeField({ task, projectId, dispatch, api, canEdit = true }) {
   const [open, setOpen] = useState(false);
   const [types, setTypes] = useState([]);
   const [loadingTypes, setLoadingTypes] = useState(false);
@@ -64,13 +64,14 @@ export default function TaskTypeField({ task, projectId, dispatch, api }) {
       <div className="flex items-center gap-1">
       <Popover open={open} onOpenChange={(v) => { setOpen(v); if (v) loadTypes(); }}>
         <PopoverTrigger asChild>
-          <button className={cn(
+          <button disabled={!canEdit} className={cn(
             'text-sm transition-colors',
             currentType
-              ? 'text-pm-text-primary bg-muted/50 px-2 py-0.5 rounded hover:bg-muted'
-              : 'text-pm-text-muted hover:text-pm-accent'
+              ? 'text-pm-text-primary bg-muted/50 px-2 py-0.5 rounded'
+              : 'text-pm-text-muted',
+            canEdit && (currentType ? 'hover:bg-muted' : 'hover:text-pm-accent')
           )}>
-            {currentType ? currentType.title : __('Add type', 'wedevs-project-manager')}
+            {currentType ? currentType.title : (canEdit ? __('Add type', 'wedevs-project-manager') : __('—', 'wedevs-project-manager'))}
           </button>
         </PopoverTrigger>
         <PopoverContent className="w-44 p-2" align="start">

--- a/views/assets/src/components/tasks/TaskDetailSheet/parts/fields/TaskTypeField.jsx
+++ b/views/assets/src/components/tasks/TaskDetailSheet/parts/fields/TaskTypeField.jsx
@@ -1,5 +1,5 @@
 import { __ } from '@wordpress/i18n';
-import React, { useCallback, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import { fetchTask } from '@store/tasksSlice';
 import { cn } from '@lib/utils';
 import {
@@ -17,6 +17,10 @@ export default function TaskTypeField({ task, projectId, dispatch, api, canEdit 
 
   const currentType = task?.type;
 
+  useEffect(() => {
+    if (!canEdit) setOpen(false);
+  }, [canEdit, task?.id]);
+
   const loadTypes = useCallback(() => {
     if (types.length > 0) return;
     setLoadingTypes(true);
@@ -30,7 +34,7 @@ export default function TaskTypeField({ task, projectId, dispatch, api, canEdit 
   }, [api, types.length]);
 
   const handleSelect = useCallback((type) => {
-    if (saving) return;
+    if (!canEdit || saving) return;
     setSaving(true);
     const typeId = type?.id === currentType?.id ? false : type?.id;
     api.post(`projects/${projectId}/tasks/${task.id}/update`, {
@@ -41,10 +45,10 @@ export default function TaskTypeField({ task, projectId, dispatch, api, canEdit 
       setOpen(false);
     }).catch(() => {})
     .finally(() => setSaving(false));
-  }, [saving, currentType, task, projectId, api, dispatch]);
+  }, [saving, currentType, task, projectId, api, dispatch, canEdit]);
 
   const handleClear = useCallback(() => {
-    if (saving) return;
+    if (!canEdit || saving) return;
     setSaving(true);
     api.post(`projects/${projectId}/tasks/${task.id}/update`, {
       title: task.title,
@@ -54,7 +58,7 @@ export default function TaskTypeField({ task, projectId, dispatch, api, canEdit 
       setOpen(false);
     }).catch(() => {})
     .finally(() => setSaving(false));
-  }, [saving, task, projectId, api, dispatch]);
+  }, [saving, task, projectId, api, dispatch, canEdit]);
 
   return (
     <div className="flex items-center h-8 px-2 rounded-md hover:bg-muted/40 transition-colors">
@@ -113,7 +117,7 @@ export default function TaskTypeField({ task, projectId, dispatch, api, canEdit 
           )}
         </PopoverContent>
       </Popover>
-      {currentType && !saving && (
+      {canEdit && currentType && !saving && (
         <button
           type="button"
           onClick={handleClear}

--- a/views/assets/src/components/tasks/TaskListSection.jsx
+++ b/views/assets/src/components/tasks/TaskListSection.jsx
@@ -52,8 +52,10 @@ export default function TaskListSection({ list, projectId, showLabels, isInbox =
   const { isPro, userCan, isManager } = usePermissions(project)
   const { setOpen: openProModal } = useProModal()
   const canCreateTask = isManager || userCan('create_task')
-  const canEditTaskList = isManager || userCan('edit_task_list')
-  const canDeleteTaskList = isManager || userCan('delete_task_list')
+  // No edit_task_list/delete_task_list capability exists — list edit/delete is
+  // manager-only (Vue parity). Bogus userCan() keys always returned false here.
+  const canEditTaskList = isManager
+  const canDeleteTaskList = isManager
 
   const api = useApi()
   const [ConfirmDialog, confirm] = useConfirm()

--- a/views/assets/src/components/tasks/TaskListsPage.jsx
+++ b/views/assets/src/components/tasks/TaskListsPage.jsx
@@ -41,7 +41,7 @@ export default function TaskListsPage() {
   const api = useApi();
   const project = useCurrentProject(projectId);
   const { isPro, userCan, isManager } = usePermissions(project);
-  const canCreateList = isManager || userCan('create_task_list');
+  const canCreateList = isManager || userCan('create_list');
 
   const { lists, loading, expandedIds, listsMeta } = useAppSelector((s) => s.taskLists);
 

--- a/views/assets/src/components/tasks/TaskListsPage.jsx
+++ b/views/assets/src/components/tasks/TaskListsPage.jsx
@@ -122,7 +122,7 @@ export default function TaskListsPage() {
   const handleCreateList = useCallback(
     async (e) => {
       e.preventDefault();
-      if (!newListTitle.trim() || creatingList) return;
+      if (!canCreateList || !newListTitle.trim() || creatingList) return;
       setCreatingList(true);
       try {
         await dispatch(
@@ -150,10 +150,20 @@ export default function TaskListsPage() {
       newListDesc,
       newListPrivate,
       creatingList,
+      canCreateList,
       toast,
       __,
     ],
   );
+
+  useEffect(() => {
+    if (!canCreateList) {
+      setShowNewList(false);
+      setNewListTitle("");
+      setNewListDesc("");
+      setNewListPrivate(false);
+    }
+  }, [canCreateList, projectId]);
 
   const allExpanded = expandedIds.length === lists.length && lists.length > 0;
 
@@ -248,7 +258,7 @@ export default function TaskListsPage() {
       </div>
 
       {/* New list form */}
-      {showNewList && (
+      {showNewList && canCreateList && (
         <form
           onSubmit={handleCreateList}
           className="rounded-xl border bg-card p-4 space-y-3"


### PR DESCRIPTION
## Problem
Several React action affordances render without the permission check the legacy Vue UI enforced, so a co-worker/client sees buttons (and can open sheets) for actions they cannot perform — e.g. the **New Project** button is visible to non-creators. A few gates also check **capability keys that do not exist**, silently misbehaving.

## Changes (this is the Free plugin half; Pro half is a sibling PR)
- **Projects** (`ProjectsPage`): gate `New Project` + `AI Create` on `canCreate`; render the project-card Edit/Complete/Settings/Delete menu only when `pmIsManager(project)` (it was unconditional, and `usePermissions()` was called without a project so `isManager` was useless per-card).
- **Task lists** (`TaskListsPage`): `userCan('create_task_list')` → `userCan('create_list')` — `create_task_list` is not a stored capability key, so it was *hiding* list creation from co-workers who were granted `create_list`. Dropped the equally-bogus `edit_task_list`/`delete_task_list` keys in `TaskListSection` → explicit `isManager` (no behaviour change).
- **Task detail sheet**: gate assignee add/remove, date edit, type and milestone edit on `canEditTask` (values stay visible to viewers; new `canEdit` prop on `TaskTypeField`/`MilestoneField`).
- **Files / Milestones**: removed nonexistent `delete_file` / `edit_milestone` / `delete_milestone` cap keys; gate on manager-or-creator (behaviour unchanged — those keys always resolved to `false`).

## Safety
Cross-checked against the Vue implementation. Managers, admins (`manage_options`) and item creators always pass; a project with **no capabilities configured** keeps every button visible (`pmUserCan` default-allow), so **no existing user loses access**. Backend permission classes remain the real guard — this only hides affordances. Actions the Vue UI never gated (comment-create, subtask-add, Gantt, Kanban drag/import, complete-task checkbox, cross-project My-Tasks create) were intentionally left unchanged.

Bundle (`views/assets/dist/`) rebuilt via `pnpm build`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved permission handling across projects, tasks, milestones, and file lists so edit, delete, and creation controls only appear when allowed (using manager/creator rules where applicable).
  * Disabled or hid task detail actions like setting dates, modifying assignees, changing task type, and updating milestone links when editing isn’t permitted.
  * Updated project/task list action gating to use the correct access rules, preventing unavailable dropdown options and forms from rendering for non-authorized users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->