### PR TITLE
chore: ignore node_modules at any depth

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /node_modules/
+node_modules/
 /vendor/
 /views/assets/js/
 /views/assets/css/pm-style.css


### PR DESCRIPTION
## Problem
`/node_modules/` has a leading slash, so it only matches the repo-root `node_modules`. Nested trees like `tests/e2e-playwright/node_modules` were NOT ignored — when that parent dir was untracked (e.g. on a branch without the e2e suite), GitHub Desktop listed thousands of `node_modules` files as uncommittable changes, risking an accidental giant commit.

## Fix
Add a recursive `node_modules/` rule (no leading slash) so `node_modules` is ignored at any depth. Verified with `git check-ignore` on nested paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the ignore rules to exclude `node_modules/` from version control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->