### PR TITLE
fix(router): set WP_Router::$request for nonce-less (JWT/mobile) requests — 500 on transformer includes

### DIFF
--- a/core/Router/WP_Router.php
+++ b/core/Router/WP_Router.php
@@ -275,17 +275,20 @@ class WP_Router {
 
 	protected function append_params( WP_REST_Request $request ) {
 		$nonce = $request->get_header( 'x_wp_nonce' );
-		
+
 		// if ( ! isset(  $_SERVER['HTTP_X_WP_NONCE'] ) ) {
 		// 	return $request;
-		// }; 
+		// };
 
 		// $nonce = sanitize_text_field( $_SERVER['HTTP_X_WP_NONCE'] );
-		
+
+		// JWT/mobile requests carry no wp_rest nonce but transformers still need the shared request object, so always set it before the nonce gate.
+		static::$request = $request;
+
 		if ( ! wp_verify_nonce( $nonce, 'wp_rest' ) ) {
 			return $request;
 		}
-		
+
 		$get_data = wp_unslash( $_GET );
 		$post_data = wp_unslash( $_POST );
 		$file_data = wp_unslash( $_FILES );
@@ -304,7 +307,6 @@ class WP_Router {
 		$request->set_query_params( $get_data );
 		$request->set_body_params( $post_data );
 		$request->set_file_params( $file_data );
-		static::$request = $request;
 		return $request;
 	}
 

--- a/src/Comment/Transformers/Comment_Transformer.php
+++ b/src/Comment/Transformers/Comment_Transformer.php
@@ -60,7 +60,8 @@ class Comment_Transformer extends TransformerAbstract {
      * @return \League\Fractal\Resource\Collection
      */
     public function includeReplies( Comment $item ) {
-        $page =  WP_Router::$request->get_param( 'reply_page' ) ?? 1;
+        $request = WP_Router::$request;
+        $page    = $request ? ( $request->get_param( 'reply_page' ) ?? 1 ) : 1;
 
         $replies = $item->replies()->paginate( wedevs_pm_config('app.comment_per_page'), ['*'], 'reply_page', $page );
 
@@ -79,7 +80,8 @@ class Comment_Transformer extends TransformerAbstract {
      * @return \League\Fractal\Resource\Collection
      */
     public function includeFiles( Comment $item ) {
-        $page =  WP_Router::$request->get_param( 'file_page' ) ?? 1;
+        $request = WP_Router::$request;
+        $page    = $request ? ( $request->get_param( 'file_page' ) ?? 1 ) : 1;
 
         $files = $item->files()->get();
 

--- a/src/Discussion_Board/Transformers/Discussion_Board_Transformer.php
+++ b/src/Discussion_Board/Transformers/Discussion_Board_Transformer.php
@@ -67,7 +67,8 @@ class Discussion_Board_Transformer extends TransformerAbstract {
     }
 
     public function includeComments( Discussion_Board $item ) {
-        $page = WP_Router::$request->get_param( 'comment_page' ) ?? 1;
+        $request = WP_Router::$request;
+        $page    = $request ? ( $request->get_param( 'comment_page' ) ?? 1 ) : 1;
 
         // Paginator::currentPageResolver(function () use ($page) {
         //     return $page;
@@ -86,7 +87,8 @@ class Discussion_Board_Transformer extends TransformerAbstract {
     }
 
     public function includeFiles( Discussion_Board $item ) {
-        $page = WP_Router::$request->get_param( 'file_page' ) ?? 1;
+        $request = WP_Router::$request;
+        $page    = $request ? ( $request->get_param( 'file_page' ) ?? 1 ) : 1;
        
 
         Paginator::currentPageResolver(function () use ($page) {

--- a/src/Milestone/Transformers/Milestone_Transformer.php
+++ b/src/Milestone/Transformers/Milestone_Transformer.php
@@ -66,7 +66,8 @@ class Milestone_Transformer extends TransformerAbstract {
     }
 
     public function includeTaskLists( Milestone $item ) {
-        $page = WP_Router::$request->get_param( 'task_list_page' ) ?? 1;
+        $request = WP_Router::$request;
+        $page    = $request ? ( $request->get_param( 'task_list_page' ) ?? 1 ) : 1;
 
         Paginator::currentPageResolver(function () use ($page) {
             return $page;
@@ -104,7 +105,8 @@ class Milestone_Transformer extends TransformerAbstract {
     }
 
     public function includeDiscussionBoards( Milestone $item ) {
-        $page = WP_Router::$request->get_param( 'discussion_page' ) ?? 1;
+        $request = WP_Router::$request;
+        $page    = $request ? ( $request->get_param( 'discussion_page' ) ?? 1 ) : 1;
 
         Paginator::currentPageResolver(function () use ($page) {
             return $page;

--- a/src/Task/Transformers/Task_Transformer.php
+++ b/src/Task/Transformers/Task_Transformer.php
@@ -165,7 +165,8 @@ class Task_Transformer extends TransformerAbstract {
      * @return \League\Fractal\Resource\Collection
      */
     public function includeBoards( Task $item ) {
-        $page = WP_Router::$request->get_param( 'board_page' ) ?? 1;
+        $request = WP_Router::$request;
+        $page    = $request ? ( $request->get_param( 'board_page' ) ?? 1 ) : 1;
 
         Paginator::currentPageResolver(function () use ($page) {
             return $page;
@@ -184,7 +185,8 @@ class Task_Transformer extends TransformerAbstract {
     }
 
     public function includeComments( Task $item ) {
-        $page = WP_Router::$request->get_param( 'comment_page' ) ?? 1;
+        $request = WP_Router::$request;
+        $page    = $request ? ( $request->get_param( 'comment_page' ) ?? 1 ) : 1;
 
         Paginator::currentPageResolver(function () use ($page) {
             return $page;
@@ -209,7 +211,8 @@ class Task_Transformer extends TransformerAbstract {
     }
 
     public function includeActivities( Task $item ) {
-        $page = WP_Router::$request->get_param( 'activitie_page' ) ?? 1;
+        $request = WP_Router::$request;
+        $page    = $request ? ( $request->get_param( 'activitie_page' ) ?? 1 ) : 1;
 
         Paginator::currentPageResolver(function () use ($page) {
             return $page;
@@ -220,7 +223,8 @@ class Task_Transformer extends TransformerAbstract {
     }
 
     public function includeFiles( Task $item ) {
-        $page = WP_Router::$request->get_param( 'file_page' ) ?? 1;
+        $request = WP_Router::$request;
+        $page    = $request ? ( $request->get_param( 'file_page' ) ?? 1 ) : 1;
 
         Paginator::currentPageResolver(function () use ($page) {
             return $page;

--- a/src/Task_List/Transformers/Task_List_Transformer.php
+++ b/src/Task_List/Transformers/Task_List_Transformer.php
@@ -83,7 +83,8 @@ class Task_List_Transformer extends TransformerAbstract {
     }
 
     public function includeComments( Task_List $item ) {
-        $page = WP_Router::$request->get_param( 'comment_page' ) ?? 1;
+        $request = WP_Router::$request;
+        $page    = $request ? ( $request->get_param( 'comment_page' ) ?? 1 ) : 1;
 
         Paginator::currentPageResolver(function () use ($page) {
             return $page;
@@ -102,7 +103,8 @@ class Task_List_Transformer extends TransformerAbstract {
     }
 
     public function includeFiles( Task_List $item ) {
-        $page = WP_Router::$request->get_param( 'file_page' ) ?? 1;
+        $request = WP_Router::$request;
+        $page    = $request ? ( $request->get_param( 'file_page' ) ?? 1 ) : 1;
 
         Paginator::currentPageResolver(function () use ($page) {
             return $page;
@@ -135,8 +137,9 @@ class Task_List_Transformer extends TransformerAbstract {
 
 
     public function includeCompleteTasks( Task_List $item ) {
-        $page           = WP_Router::$request->get_param( 'complete_task_page' ) ?? 1;
-        $per_page_count = WP_Router::$request->get_param( 'complete_task_per_page' ) ?? 0;
+        $request        = WP_Router::$request;
+        $page           = $request ? ( $request->get_param( 'complete_task_page' ) ?? 1 ) : 1;
+        $per_page_count = $request ? ( $request->get_param( 'complete_task_per_page' ) ?? 0 ) : 0;
 
         $per_page = wedevs_pm_get_setting( 'complete_tasks_per_page' );
         $per_page = $per_page ? $per_page : 5;
@@ -163,8 +166,9 @@ class Task_List_Transformer extends TransformerAbstract {
     }
 
     public function includeIncompleteTasks( Task_List $item ) {
-        $page           = WP_Router::$request->get_param( 'incomplete_task_page' ) ?? 1;
-        $per_page_count = WP_Router::$request->get_param( 'incomplete_task_per_page' ) ?? 0;
+        $request        = WP_Router::$request;
+        $page           = $request ? ( $request->get_param( 'incomplete_task_page' ) ?? 1 ) : 1;
+        $per_page_count = $request ? ( $request->get_param( 'incomplete_task_per_page' ) ?? 0 ) : 0;
 
         Paginator::currentPageResolver(function () use ($page) {
             return $page;

--- a/src/User/Transformers/User_Transformer.php
+++ b/src/User/Transformers/User_Transformer.php
@@ -155,9 +155,10 @@ class User_Transformer extends TransformerAbstract {
                 }
             });
 
-            $start_at = WP_Router::$request->get_param( 'start_at' ) ?? false;
-            $due_date = WP_Router::$request->get_param( 'due_date' ) ?? false;
-            
+            $request  = WP_Router::$request;
+            $start_at = $request ? ( $request->get_param( 'start_at' ) ?? false ) : false;
+            $due_date = $request ? ( $request->get_param( 'due_date' ) ?? false ) : false;
+
             if ( ! empty( $start_at ) && ! empty( $due_date ) ) {
                 
                 $total_current_tasks = $tasks->where( 'status', 'incomplete' )->filter( function( $item ) use ( $start_at, $due_date, &$total ) {
@@ -273,8 +274,9 @@ class User_Transformer extends TransformerAbstract {
         $project_ids = User_Role::where( 'user_id', $item->ID )->get(['project_id'])->toArray();
         $project_ids = wp_list_pluck( $project_ids, 'project_id' );
 
-        $page = WP_Router::$request->get_param( 'mytask_activities_page' ) ?? 1;
-        $per_page = WP_Router::$request->get_param( 'mytask_activities_per_page' ) ?? 15;
+        $request  = WP_Router::$request;
+        $page     = $request ? ( $request->get_param( 'mytask_activities_page' ) ?? 1 ) : 1;
+        $per_page = $request ? ( $request->get_param( 'mytask_activities_per_page' ) ?? 15 ) : 15;
 
         Paginator::currentPageResolver(function () use ($page) {
             return $page;
@@ -294,8 +296,9 @@ class User_Transformer extends TransformerAbstract {
     }
 
     public function includeGraph ( User $item ) {
-        $start_at = WP_Router::$request->get_param( 'start_at' ) ?? false;
-        $due_date = WP_Router::$request->get_param( 'due_date' ) ?? false;
+        $request  = WP_Router::$request;
+        $start_at = $request ? ( $request->get_param( 'start_at' ) ?? false ) : false;
+        $due_date = $request ? ( $request->get_param( 'due_date' ) ?? false ) : false;
 
         if ( $start_at && $due_date ) {
             $first_day = gmdate( 'Y-m-d', strtotime( $start_at ) );


### PR DESCRIPTION
Fixes weDevsOfficial/pm-pro#384 — mobile app (AppBridge JWT) got a **500 fatal** on `GET /pm/v2/projects/{id}/discussion-boards` (and any `?with=` include).

## Root cause
JWT/mobile requests carry no `wp_rest` nonce, so `WP_Router::append_params()` bailed **before** setting `WP_Router::$request`, leaving it `null`. `Discussion_Board_Transformer`'s default `files` include then called `WP_Router::$request->get_param()` on `null` → fatal. Tasks/projects survived because their default includes don't touch the request.

## Fix
1. **`WP_Router::append_params`** — set `static::$request = $request` **before** the nonce gate. The nonce still gates only the `$_GET/$_POST/$_FILES` merge, unchanged. Request object now always exists; nonce web path behaves identically.
2. **Transformer null-guards** — hardened every `WP_Router::$request->get_param()` read (Discussion_Board, Task, Task_List, Milestone, Comment, User transformers), preserving each existing pagination default exactly (pattern already used in `Transformer_Manager`).

Verified: no consumer relies on `$request` being null; `php -l` clean on all 7 files; pagination defaults unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when viewing related items, comments, files, and activity lists.
  * Fixed issues that could occur when request details were unavailable, helping pages load with sensible defaults instead of failing.
  * Pagination now falls back to safe default values more consistently across task, discussion, milestone, comment, and user views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->