### PR TITLE
chore(claude): fix line-endings rule — source is CRLF, not LF

### DIFF
--- a/.claude/rules/code-style.md
+++ b/.claude/rules/code-style.md
@@ -20,7 +20,7 @@
 - **No raw SQL** for table inserts/updates — use Eloquent. Raw SQL acceptable only for migrations / schema introspection.
 - **WordPress text domain:** literal `'wedevs-project-manager'` (string). Never a variable. Never concatenated.
 - **Hooks:** `do_action()` / `apply_filters()` named `pm_<verb>_<noun>` (e.g., `pm_after_new_task`).
-- **Line endings:** LF (`.editorconfig`).
+- **Line endings:** despite `.editorconfig` saying `eol=lf`, the committed **source files (PHP/JS/JSX/CSS) are actually CRLF** (dotfiles/`.md` under `.claude/` are LF). **Match whatever the file you're editing already uses** — never flip a file's endings, or the whole file churns in the diff. For CRLF source, re-normalize edits with `perl -0777 -i -pe 's/\r?\n/\r\n/g' <file>`.
 - **Final newline** at EOF.
 
 ## JavaScript / JSX


### PR DESCRIPTION
The `.claude/rules/code-style.md` line-endings rule said **LF (`.editorconfig`)**, but the committed source files (PHP/JS/JSX/CSS) are actually **CRLF** — only the `.claude/` dotfiles/`.md` are LF. Editing a source file as LF churns the whole file in the diff.

Rule now: match whatever endings the file already uses; for CRLF source, re-normalize edits with `perl -0777 -i -pe 's/\r?\n/\r\n/g' <file>`.

Docs-only change to the agent rules; no code impact.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated code-style guidance to accurately describe line-ending conventions.
  * Added instructions to preserve existing line endings and prevent unnecessary formatting changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->