### PR TITLE
fix(security): close unauthenticated RCE chain (Patchstack, CVSS 9.8)

### DIFF
--- a/core/Permissions/Administrator.php
+++ b/core/Permissions/Administrator.php
@@ -7,6 +7,6 @@ use WP_REST_Request;
 
 class Administrator extends Abstract_Permission {
     public function check() {
-        return true;
+        return current_user_can( 'manage_options' );
     }
 }

--- a/core/Permissions/Public_Access.php
+++ b/core/Permissions/Public_Access.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace WeDevs\PM\Core\Permissions;
+
+use WeDevs\PM\Core\Permissions\Abstract_Permission;
+use WP_REST_Request;
+
+/**
+ * Explicit opt-in for endpoints that must stay reachable without a WordPress
+ * session (third-party webhooks). The router denies routes that declare no
+ * permission, so "public" now has to be stated instead of implied by omission.
+ * Any route using this MUST authenticate the caller itself.
+ */
+class Public_Access extends Abstract_Permission {
+    public function check() {
+        return true;
+    }
+}

--- a/core/Router/WP_Router.php
+++ b/core/Router/WP_Router.php
@@ -103,14 +103,21 @@ class WP_Router {
 	 *
 	 * @param  array $permissions (Array of class namespaces of permission classes.)
 	 *
-	 * @return boolean (Return true if permitted; ortherwise false.)
+	 * @return boolean|\WP_Error (Return true if permitted; otherwise false or WP_Error.)
 	 */
 	private function check_permission( WP_REST_Request $request, $permissions ) {
 		$permitted   = array();
 		$merge_error = false;
 
+		// Fail closed. A route that forgets ->permission() used to be public to
+		// unauthenticated callers. Genuinely public endpoints must opt in with
+		// WeDevs\PM\Core\Permissions\Public_Access.
 		if ( empty( $permissions ) ) {
-			$permitted = true;
+			return new \WP_Error(
+				'wedevs_pm_no_permission',
+				__( 'You have no permission to access this endpoint.', 'wedevs-project-manager' ),
+				array( 'status' => rest_authorization_required_code() )
+			);
 		}
 
 		foreach ( $permissions as $permission ) {

--- a/libs/functions.php
+++ b/libs/functions.php
@@ -1475,3 +1475,25 @@ function wedevs_pm_load_headway_badge( $selector = '#pm-headway-icon' ) {
 
     <?php
 }
+
+/**
+ * Unserialize a stored value without ever instantiating a class.
+ *
+ * pm_meta / activity / comment payloads are written by project members, so a
+ * plain unserialize() there is a PHP object injection sink (Patchstack #455).
+ * allowed_classes => false turns any serialized object into
+ * __PHP_Incomplete_Class, which has no magic methods to fire.
+ *
+ * @param mixed $value
+ *
+ * @return mixed
+ */
+function wedevs_pm_safe_unserialize( $value ) {
+    if ( ! is_string( $value ) || ! is_serialized( $value ) ) {
+        return $value;
+    }
+
+    $unserialized = @unserialize( $value, [ 'allowed_classes' => false ] );
+
+    return false === $unserialized && 'b:0;' !== $value ? $value : $unserialized;
+}

--- a/routes/file.php
+++ b/routes/file.php
@@ -24,4 +24,5 @@ $wedevs_pm_router->post( 'projects/{project_id}/files/{file_id}/delete', 'WeDevs
 $wedevs_pm_router->get( 'projects/{project_id}/files/{file_id}/users/{user_id}/download', 'WeDevs/PM/File/Controllers/File_Controller@download' )
     ->permission( ['WeDevs\PM\Core\Permissions\Access_Project'] );
 
-$wedevs_pm_router->get( 'get-mime-type-icon', 'WeDevs/PM/File/Controllers/File_Controller@get_mime_type_icon' );
+$wedevs_pm_router->get( 'get-mime-type-icon', 'WeDevs/PM/File/Controllers/File_Controller@get_mime_type_icon' )
+    ->permission( ['WeDevs\PM\Core\Permissions\Authentic'] );

--- a/routes/trello.php
+++ b/routes/trello.php
@@ -4,28 +4,44 @@ use WeDevs\PM\Core\Router\Router;
 use WeDevs\PM\Core\Permissions\Authentic;
 $wedevs_pm_router = Router::singleton();
 
-$wedevs_pm_router->get( 'trello', 'WeDevs/PM/Imports/Controllers/Trello_Controller@index' );
-$wedevs_pm_router->post( 'trello', 'WeDevs/PM/Imports/Controllers/Trello_Controller@index' );
+$wedevs_pm_router->get( 'trello', 'WeDevs/PM/Imports/Controllers/Trello_Controller@index' )
+    ->permission( ['WeDevs\PM\Core\Permissions\Settings_Page_Access'] );
+$wedevs_pm_router->post( 'trello', 'WeDevs/PM/Imports/Controllers/Trello_Controller@index' )
+    ->permission( ['WeDevs\PM\Core\Permissions\Settings_Page_Access'] );
 
-$wedevs_pm_router->get( 'trello/test', 'WeDevs/PM/Imports/Controllers/Trello_Controller@test' );
-$wedevs_pm_router->post( 'trello/test', 'WeDevs/PM/Imports/Controllers/Trello_Controller@test' );
+$wedevs_pm_router->get( 'trello/test', 'WeDevs/PM/Imports/Controllers/Trello_Controller@test' )
+    ->permission( ['WeDevs\PM\Core\Permissions\Settings_Page_Access'] );
+$wedevs_pm_router->post( 'trello/test', 'WeDevs/PM/Imports/Controllers/Trello_Controller@test' )
+    ->permission( ['WeDevs\PM\Core\Permissions\Settings_Page_Access'] );
 
 
-$wedevs_pm_router->get( 'trello/get_user', 'WeDevs/PM/Imports/Controllers/Trello_Controller@get_user' );
-$wedevs_pm_router->post( 'trello/get_user', 'WeDevs/PM/Imports/Controllers/Trello_Controller@get_user' );
+$wedevs_pm_router->get( 'trello/get_user', 'WeDevs/PM/Imports/Controllers/Trello_Controller@get_user' )
+    ->permission( ['WeDevs\PM\Core\Permissions\Settings_Page_Access'] );
+$wedevs_pm_router->post( 'trello/get_user', 'WeDevs/PM/Imports/Controllers/Trello_Controller@get_user' )
+    ->permission( ['WeDevs\PM\Core\Permissions\Settings_Page_Access'] );
 
 
-$wedevs_pm_router->get( 'trello/get_boards', 'WeDevs/PM/Imports/Controllers/Trello_Controller@get_boards' );
-$wedevs_pm_router->post( 'trello/get_boards', 'WeDevs/PM/Imports/Controllers/Trello_Controller@get_boards' );
+$wedevs_pm_router->get( 'trello/get_boards', 'WeDevs/PM/Imports/Controllers/Trello_Controller@get_boards' )
+    ->permission( ['WeDevs\PM\Core\Permissions\Settings_Page_Access'] );
+$wedevs_pm_router->post( 'trello/get_boards', 'WeDevs/PM/Imports/Controllers/Trello_Controller@get_boards' )
+    ->permission( ['WeDevs\PM\Core\Permissions\Settings_Page_Access'] );
 
-$wedevs_pm_router->get( 'trello/get_lists', 'WeDevs/PM/Imports/Controllers/Trello_Controller@get_lists' );
-$wedevs_pm_router->post( 'trello/get_lists', 'WeDevs/PM/Imports/Controllers/Trello_Controller@get_lists' );
+$wedevs_pm_router->get( 'trello/get_lists', 'WeDevs/PM/Imports/Controllers/Trello_Controller@get_lists' )
+    ->permission( ['WeDevs\PM\Core\Permissions\Settings_Page_Access'] );
+$wedevs_pm_router->post( 'trello/get_lists', 'WeDevs/PM/Imports/Controllers/Trello_Controller@get_lists' )
+    ->permission( ['WeDevs\PM\Core\Permissions\Settings_Page_Access'] );
 
-$wedevs_pm_router->get( 'trello/get_cards', 'WeDevs/PM/Imports/Controllers/Trello_Controller@get_cards' );
-$wedevs_pm_router->post( 'trello/get_cards', 'WeDevs/PM/Imports/Controllers/Trello_Controller@get_cards' );
+$wedevs_pm_router->get( 'trello/get_cards', 'WeDevs/PM/Imports/Controllers/Trello_Controller@get_cards' )
+    ->permission( ['WeDevs\PM\Core\Permissions\Settings_Page_Access'] );
+$wedevs_pm_router->post( 'trello/get_cards', 'WeDevs/PM/Imports/Controllers/Trello_Controller@get_cards' )
+    ->permission( ['WeDevs\PM\Core\Permissions\Settings_Page_Access'] );
 
-$wedevs_pm_router->get( 'trello/get_subcards', 'WeDevs/PM/Imports/Controllers/Trello_Controller@get_subcards' );
-$wedevs_pm_router->post( 'trello/get_subcards', 'WeDevs/PM/Imports/Controllers/Trello_Controller@get_subcards' );
+$wedevs_pm_router->get( 'trello/get_subcards', 'WeDevs/PM/Imports/Controllers/Trello_Controller@get_subcards' )
+    ->permission( ['WeDevs\PM\Core\Permissions\Settings_Page_Access'] );
+$wedevs_pm_router->post( 'trello/get_subcards', 'WeDevs/PM/Imports/Controllers/Trello_Controller@get_subcards' )
+    ->permission( ['WeDevs\PM\Core\Permissions\Settings_Page_Access'] );
 
-$wedevs_pm_router->get( 'trello/get_users', 'WeDevs/PM/Imports/Controllers/Trello_Controller@get_users' );
-$wedevs_pm_router->post( 'trello/get_users', 'WeDevs/PM/Imports/Controllers/Trello_Controller@get_users' );
+$wedevs_pm_router->get( 'trello/get_users', 'WeDevs/PM/Imports/Controllers/Trello_Controller@get_users' )
+    ->permission( ['WeDevs\PM\Core\Permissions\Settings_Page_Access'] );
+$wedevs_pm_router->post( 'trello/get_users', 'WeDevs/PM/Imports/Controllers/Trello_Controller@get_users' )
+    ->permission( ['WeDevs\PM\Core\Permissions\Settings_Page_Access'] );

--- a/src/Activity/Helper/Activity.php
+++ b/src/Activity/Helper/Activity.php
@@ -176,27 +176,27 @@ class Activity {
     }
 
     private function parse_meta_for_task( $activity ) {
-        return is_serialized( $activity->meta ) ? maybe_unserialize( $activity->meta ) : $activity->meta;
+        return is_serialized( $activity->meta ) ? wedevs_pm_safe_unserialize( $activity->meta ) : $activity->meta;
     }
 
     private function parse_meta_for_task_list( $activity ) {
-        return is_serialized( $activity->meta ) ? maybe_unserialize( $activity->meta ) : $activity->meta;
+        return is_serialized( $activity->meta ) ? wedevs_pm_safe_unserialize( $activity->meta ) : $activity->meta;
     }
 
     private function parse_meta_for_discussion_board( $activity ) {
-        return is_serialized( $activity->meta ) ? maybe_unserialize( $activity->meta ) : $activity->meta;
+        return is_serialized( $activity->meta ) ? wedevs_pm_safe_unserialize( $activity->meta ) : $activity->meta;
     }
 
     private function parse_meta_for_milestone( $activity ) {
-        return is_serialized( $activity->meta ) ? maybe_unserialize( $activity->meta ) : $activity->meta;
+        return is_serialized( $activity->meta ) ? wedevs_pm_safe_unserialize( $activity->meta ) : $activity->meta;
     }
 
     private function parse_meta_for_project( $activity ) {
-        return is_serialized( $activity->meta ) ? maybe_unserialize( $activity->meta ) : $activity->meta;
+        return is_serialized( $activity->meta ) ? wedevs_pm_safe_unserialize( $activity->meta ) : $activity->meta;
     }
 
     private function parse_meta_for_file( $activity ) {
-        return is_serialized( $activity->meta ) ? maybe_unserialize( $activity->meta ) : $activity->meta;
+        return is_serialized( $activity->meta ) ? wedevs_pm_safe_unserialize( $activity->meta ) : $activity->meta;
     }
 
     private function parse_meta_for_comment( $activity ) {
@@ -206,7 +206,7 @@ class Activity {
             return $meta;
         }
 
-        $activity->meta = is_serialized( $activity->meta ) ? maybe_unserialize( $activity->meta ) : $activity->meta;
+        $activity->meta = is_serialized( $activity->meta ) ? wedevs_pm_safe_unserialize( $activity->meta ) : $activity->meta;
 
         foreach ($activity->meta as $key => $value) {
             if ( $key == 'commentable_type' && $value == 'file' ) {

--- a/src/Activity/Models/Activity.php
+++ b/src/Activity/Models/Activity.php
@@ -32,7 +32,7 @@ class Activity extends Eloquent {
     }
 
     public function getMetaAttribute( $value ) {
-        return unserialize( $value );
+        return wedevs_pm_safe_unserialize( $value );
     }
 
     public function project() {

--- a/src/Comment/Models/Comment.php
+++ b/src/Comment/Models/Comment.php
@@ -60,6 +60,6 @@ class Comment extends Eloquent {
     }
 
     public function getMentionedUsersAttribute( $value ) {
-        return unserialize( $value );
+        return wedevs_pm_safe_unserialize( $value );
     }
 }

--- a/src/Common/Models/Meta.php
+++ b/src/Common/Models/Meta.php
@@ -29,7 +29,7 @@ class Meta extends Eloquent {
     }
 
     public function getMetaValueAttribute( $value ) {
-        return maybe_unserialize( $value );
+        return wedevs_pm_safe_unserialize( $value );
     }
 
     public function setMetaValueAttribute( $value ) {

--- a/src/Imports/Helpers/Import_helper.php
+++ b/src/Imports/Helpers/Import_helper.php
@@ -190,9 +190,19 @@ class Import_helper {
                             'user_nicename' => $ind_user->username,
                             'first_name' => $ind_user->fullName,
                             'role' => 'subscriber',
-                            'user_pass' => md5('123456#')
+                            // Never a predictable password. The imported user sets
+                            // their own through the reset link below.
+                            'user_pass' => wp_generate_password( 24, true, true )
                         ];
                         $user_id = wp_insert_user( $userdata ) ;
+
+                        if ( ! is_wp_error( $user_id ) ) {
+                            wp_new_user_notification( $user_id, null, 'user' );
+                        }
+                    }
+
+                    if ( is_wp_error( $user_id ) ) {
+                        continue;
                     }
                     $local_project_id = $project_arr[0];
                     $local_task_id = $project_arr[2];

--- a/src/Milestone/Controllers/Milestone_Controller.php
+++ b/src/Milestone/Controllers/Milestone_Controller.php
@@ -299,8 +299,10 @@ class Milestone_Controller {
 
     public function privacy( WP_REST_Request $request ) {
         $project_id = intval( $request->get_param( 'project_id' ) );
-        $milestone_id = $request->get_param( 'milestone_id' );
-        $privacy = $request->get_param( 'is_private' );
+        $milestone_id = intval( $request->get_param( 'milestone_id' ) );
+        // Stored in pm_meta and read back through unserialize(); anything but an
+        // int here is a PHP object injection vector.
+        $privacy = intval( $request->get_param( 'is_private' ) );
         $milestone = Milestone::find( $milestone_id );
         $milestone->update_model( [
             'is_private' => $privacy

--- a/src/My_Task/Controllers/MyTask_Controller.php
+++ b/src/My_Task/Controllers/MyTask_Controller.php
@@ -623,7 +623,7 @@ class MyTask_Controller {
         $settings = explode( '|', $settings );
 
         foreach ( $settings as $key => $setting ) {
-            return !empty( $setting ) ? maybe_unserialize( $setting ) : '';
+            return !empty( $setting ) ? wedevs_pm_safe_unserialize( $setting ) : '';
         }
 
         return [];

--- a/src/Settings/Models/Settings.php
+++ b/src/Settings/Models/Settings.php
@@ -76,7 +76,7 @@ class Settings extends Eloquent {
         }
         
         // If JSON decode failed, try unserialize (for backward compatibility with old data)
-        $unserialized = @unserialize( $value );
+        $unserialized = @unserialize( $value, [ 'allowed_classes' => false ] );
         if ( $unserialized !== false ) {
             return $unserialized;
         }

--- a/src/Task/Controllers/Task_Controller.php
+++ b/src/Task/Controllers/Task_Controller.php
@@ -664,8 +664,10 @@ class Task_Controller {
 
     public function privacy( WP_REST_Request $request ) {
         $project_id = intval( $request->get_param( 'project_id' ) );
-        $task_id = $request->get_param( 'task_id' );
-        $privacy = $request->get_param( 'is_private' );
+        $task_id = intval( $request->get_param( 'task_id' ) );
+        // Stored in pm_meta and read back through unserialize(); anything but an
+        // int here is a PHP object injection vector.
+        $privacy = intval( $request->get_param( 'is_private' ) );
         $task = Task::find( $task_id );
         $task->update_model( [
             'is_private' => $privacy

--- a/src/Task/Helper/Task.php
+++ b/src/Task/Helper/Task.php
@@ -718,13 +718,7 @@ class Task {
 		foreach ( $this->tasks as $key => $task ) {
 			$filter_metas = empty( $metas[$task->id] ) ? [] : $metas[$task->id];
 			foreach ( $filter_metas as $key => $filter_meta ) {
-				$meta_value = @unserialize( $filter_meta->meta_value );
-				
-				if ($meta_value === false && $filter_meta->meta_value !== 'b:0;') {
-				    $task->meta[$filter_meta->meta_key] = $filter_meta->meta_value;
-				} else {
-					$task->meta[$filter_meta->meta_key] = maybe_unserialize( $filter_meta->meta_value );
-				}
+				$task->meta[$filter_meta->meta_key] = wedevs_pm_safe_unserialize( $filter_meta->meta_value );
 			}
 		}
 		


### PR DESCRIPTION
Closes weDevsOfficial/pm-pro#455

Fixes the Patchstack report (CVSS 9.8, unauthenticated RCE) against WP Project Manager <= 4.0.6, plus everything the same sweep turned up in the Free plugin.

## The reported chain

The report chained three defects into unauthenticated remote code execution:

1. an unauthenticated attacker creates a working WordPress account,
2. that account (a project `co_worker`) injects a serialized PHP object,
3. the plugin deserializes it, and any POP gadget in the loaded class set turns that into code execution.

## What was wrong and what changed

### 1. The router failed open

`core/Router/WP_Router.php::check_permission()`

```php
if ( empty( $permissions ) ) {
    $permitted = true;   // a route with no ->permission() was public
}
```

Any route that forgot its permission chain was reachable without authentication. It now returns a `WP_Error` with `rest_authorization_required_code()`. Endpoints that genuinely have to stay public opt in explicitly through the new `WeDevs\PM\Core\Permissions\Public_Access` class instead of relying on omission — none in Free need it today, but the Pro webhook does.

### 2. `routes/trello.php` declared 16 routes with no permission

`trello`, `trello/test`, `trello/get_user`, `trello/get_boards`, `trello/get_lists`, `trello/get_cards`, `trello/get_subcards`, `trello/get_users` — GET and POST each. They drive the Trello import: the caller supplies **their own** Trello `app_key`/`app_token`, so the plugin happily imports an attacker's board on an unauthenticated request.

All 16 now require `Settings_Page_Access`, matching the `AdminRoute` guard already on the Tools screen that calls them.

`GET get-mime-type-icon` in `routes/file.php` was also ungated; it now requires `Authentic`.

### 3. `Core\Permissions\Administrator` never checked anything

```php
class Administrator extends Abstract_Permission {
    public function check() {
        return true;
    }
}
```

Every route using it was public too (`pusher/test`). It now checks `manage_options`, mirroring the Pro class of the same name.

### 4. Hard-coded password

`src/Imports/Helpers/Import_helper.php::save_imported_user()` created accounts with `md5('123456#')` = `dcf877b18896c5fa70fbbd4dc9c8adb0` (CWE-798) and added them to the imported project as `co_worker`. It worked even with **"Anyone can register" disabled**.

Imported users now get `wp_generate_password( 24, true, true )` and the standard new-user notification so they set their own password. `wp_insert_user()` errors are skipped instead of being passed on as a user id.

### 5. PHP object injection

Write side — `Task_Controller::privacy()` and `Milestone_Controller::privacy()` stored the raw `is_private` request param in `pm_meta`. Both now `intval()` it, matching what `Discussion_Board_Controller` already did.

Read side — `Task::include_metas()` ran `@unserialize()` on that stored value, so the attacker chose the class and property values of an object the plugin instantiated. Every `unserialize()` of stored plugin data now goes through the new `wedevs_pm_safe_unserialize()`, which passes `allowed_classes => false`:

```php
$unserialized = @unserialize( $value, [ 'allowed_classes' => false ] );
```

A serialized object degrades to `__PHP_Incomplete_Class`, which has no magic methods to fire — so even if a new write path leaks in later, there is no gadget to reach. Applied to `Task/Helper/Task.php`, `Common/Models/Meta.php`, `Activity/Models/Activity.php`, `Activity/Helper/Activity.php` (7 call sites), `Comment/Models/Comment.php`, `My_Task/Controllers/MyTask_Controller.php`, and `Settings/Models/Settings.php`.

## Proof

Unauthenticated, before → after (local `we-pm.test`, WP 6.x, PHP 7.4):

```
GET /wp-json/pm/v2/trello/get_boards                 200 → 401 rest_forbidden
GET /wp-json/pm/v2/trello/get_users                  200 → 401 rest_forbidden
GET /wp-json/pm/v2/get-mime-type-icon                200 → 401 rest_forbidden
```

Authenticated admin, still working:

```
GET pm/v2/projects/1/tasks?per_page=2       200  (12,924 bytes, meta reads intact)
GET pm/v2/projects/1/task-lists?per_page=2  200  (8,908 bytes)
GET pm/v2/trello/get_boards                 200
```

Object injection: a task's `privacy` meta can no longer hold anything but an int, and even a pre-existing poisoned row now deserializes to `__PHP_Incomplete_Class` rather than instantiating the gadget.

## Not broken

- Trello import still runs for an admin (the Tools screen is already `AdminRoute`, so the gate matches the UI).
- Task/task-list/milestone privacy toggles unchanged for callers that send `0`/`1` — which is all of `views/assets/src`.
- `wedevs_pm_safe_unserialize()` returns arrays and scalars exactly as `maybe_unserialize()` did, and hands back the raw string when the payload is not serialized, so stored settings, activity meta and comment mentions keep working.
- No frontend change needed in Free.
- `vendor/bin/phpcs` clean on every touched file; `php -l` clean under PHP 7.4 (the version in `readme.txt`).
