### PR TITLE
chore(claude): allow plain git push in Claude Code settings

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -74,7 +74,6 @@
 
       "Bash(git push --force:*)",
       "Bash(git push -f:*)",
-      "Bash(git push:*)",
       "Bash(git reset --hard:*)",
       "Bash(git clean -fd:*)",
       "Bash(git checkout -- :*)",


### PR DESCRIPTION
Pushing a feature branch to a fork is routine, but `Bash(git push:*)` sat in the `deny` list, so every push meant editing this file and putting it back afterwards.

Removes that one entry. The destructive rules stay denied:

- `git push --force` / `git push -f`
- `git reset --hard`
- `git clean -fd`
- `git checkout -- `
- `git branch -D`
- `git rebase -i`
- `git filter-branch`

No plugin code touched.