### PR TITLE
fix(security): scope task + per-user REST routes to the caller's projects (WPScan #42604, #43987)

### DIFF
--- a/core/Permissions/Access_User.php
+++ b/core/Permissions/Access_User.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace WeDevs\PM\Core\Permissions;
+
+use WeDevs\PM\Core\Permissions\Abstract_Permission;
+
+/**
+ * Guards the per-user routes (users/{id}/...).
+ *
+ * A caller may read their own resources; reading another user's activity feed,
+ * tasks or email address requires a project-management capability. Without this
+ * any logged-in user could pass another user's id in the URL and read it
+ * (WPScan #43987).
+ */
+class Access_User extends Abstract_Permission {
+
+    public function check() {
+        $id = intval( $this->request->get_param( 'id' ) );
+
+        if ( $id === get_current_user_id() ) {
+            return true;
+        }
+
+        if ( wedevs_pm_user_can_access() ) {
+            return true;
+        }
+
+        return new \WP_Error( 'pm_user', __( "You have no permission.", "wedevs-project-manager" ) );
+    }
+}

--- a/routes/mytask.php
+++ b/routes/mytask.php
@@ -2,17 +2,18 @@
 
 use WeDevs\PM\Core\Router\Router;
 use WeDevs\PM\Core\Permissions\Authentic;
+use WeDevs\PM\Core\Permissions\Access_User;
 
 $wedevs_pm_router = Router::singleton();
 
 $wedevs_pm_router->get( 'users/{id}/user-activities', 'WeDevs/PM/My_Task/Controllers/MyTask_Controller@user_activities' )
-    ->permission(['WeDevs\PM\Core\Permissions\Authentic']);
+    ->permission(['WeDevs\PM\Core\Permissions\Access_User']);
 
 $wedevs_pm_router->get( 'users/{id}/tasks', 'WeDevs/PM/My_Task/Controllers/MyTask_Controller@user_tasks_by_type' )
-    ->permission(['WeDevs\PM\Core\Permissions\Authentic']);
+    ->permission(['WeDevs\PM\Core\Permissions\Access_User']);
 
 $wedevs_pm_router->get( 'users/{id}/tasks/calender', 'WeDevs/PM/My_Task/Controllers/MyTask_Controller@user_calender_tasks' )
-    ->permission(['WeDevs\PM\Core\Permissions\Authentic']);
+    ->permission(['WeDevs\PM\Core\Permissions\Access_User']);
 
 $wedevs_pm_router->get( 'assigned_users', 'WeDevs/PM/My_Task/Controllers/MyTask_Controller@assigned_users' )
     ->permission(['WeDevs\PM\Core\Permissions\Authentic']);

--- a/routes/task.php
+++ b/routes/task.php
@@ -26,7 +26,7 @@ $wedevs_pm_router->post( 'projects/{project_id}/tasks', 'WeDevs/PM/Task/Controll
     ->sanitizer( 'WeDevs\PM\Task\Sanitizers\Task_Sanitizer' );
 
 $wedevs_pm_router->post( 'projects/{project_id}/tasks/sorting', 'WeDevs/PM/Task/Controllers/Task_Controller@task_sorting' )
-    ->permission( [ $wedevs_pm_authentic ] );
+    ->permission( [ 'WeDevs\PM\Core\Permissions\Access_Project' ] );
 
 $wedevs_pm_router->get( 'projects/{project_id}/tasks/{task_id}', 'WeDevs/PM/Task/Controllers/Task_Controller@show' )
     ->permission(['WeDevs\PM\Core\Permissions\Access_Project']);

--- a/src/Task/Controllers/Task_Controller.php
+++ b/src/Task/Controllers/Task_Controller.php
@@ -684,6 +684,31 @@ class Task_Controller {
         $task       = [];
         $sender_list_id = false;
 
+        // Access_Project proves the caller belongs to $project_id. Bind every id
+        // supplied in the body to that same project so a member of one project
+        // cannot reorder or relocate another project's tasks (WPScan #42604).
+        if ( $list_id && ! Board::where( 'id', $list_id )->where( 'project_id', $project_id )->exists() ) {
+            wp_send_json_error( [ 'message' => __( 'The list does not belong to this project.', 'wedevs-project-manager' ) ], 403 );
+        }
+
+        if ( $task_id && ! Task::where( 'id', $task_id )->where( 'project_id', $project_id )->exists() ) {
+            wp_send_json_error( [ 'message' => __( 'The task does not belong to this project.', 'wedevs-project-manager' ) ], 403 );
+        }
+
+        if ( ! empty( $orders ) && is_array( $orders ) ) {
+            $order_ids = array_values( array_unique( array_filter( array_map( function ( $order ) {
+                return empty( $order['id'] ) ? 0 : intval( $order['id'] );
+            }, $orders ) ) ) );
+
+            if ( ! empty( $order_ids ) ) {
+                $valid = Task::whereIn( 'id', $order_ids )->where( 'project_id', $project_id )->count();
+
+                if ( intval( $valid ) !== count( $order_ids ) ) {
+                    wp_send_json_error( [ 'message' => __( 'One or more tasks do not belong to this project.', 'wedevs-project-manager' ) ], 403 );
+                }
+            }
+        }
+
         if ( isset( $receive ) && $receive == 1 ) {
             $task = wedevs_pm_get_task( $task_id );
             $sender_list_id = $task ? $task['data']['task_list']['data']['id'] : false;

--- a/src/Task/Helper/Task.php
+++ b/src/Task/Helper/Task.php
@@ -1249,6 +1249,7 @@ class Task {
 			->where_completed_at()
 			->where_created_at()
 			->where_project_id()
+			->where_membership()
 			->where_users()
 			->where_lists()
 			->where_milestone()
@@ -1413,6 +1414,44 @@ class Task {
 		$project_id = $this->get_prepare_data( $project_id );
 
 		$this->where .= $wpdb->prepare( " AND {$this->tb_tasks}.project_id IN ($format)", $project_id );
+
+		return $this;
+	}
+
+	/**
+	 * Constrain the query to the projects the current user belongs to.
+	 *
+	 * Managers / admins may query across every project; everyone else only sees
+	 * tasks in projects they are a member of. Without this a logged-in user could
+	 * omit project_id and read every project's tasks (WPScan #42604).
+	 *
+	 * @return self
+	 */
+	private function where_membership() {
+		if ( wedevs_pm_user_can_access() ) {
+			return $this;
+		}
+
+		global $wpdb;
+		$user_id      = get_current_user_id();
+		$tb_role_user = esc_sql( wedevs_pm_tb_prefix() . 'pm_role_user' );
+
+		$project_ids = $wpdb->get_col( $wpdb->prepare(
+			"SELECT DISTINCT project_id FROM {$tb_role_user} WHERE user_id = %d",
+			$user_id
+		) );
+
+		$project_ids = array_map( 'absint', (array) $project_ids );
+
+		if ( empty( $project_ids ) ) {
+			// Member of no project sees no tasks.
+			$this->where .= ' AND 0 = 1';
+
+			return $this;
+		}
+
+		$format = implode( ',', array_fill( 0, count( $project_ids ), '%d' ) );
+		$this->where .= $wpdb->prepare( " AND {$this->tb_tasks}.project_id IN ($format)", $project_ids );
 
 		return $this;
 	}


### PR DESCRIPTION
Refs weDevsOfficial/pm-pro#461 (WPScan **#42604** and **#43987**).

Two of the three reports in #461 are cross-project data-access defects in the Free plugin: routes gated only by `Authentic` (logged-in only), with no constraint tying the query/ids to the projects the caller belongs to. This PR closes both. The third report (**#45258**, unauthenticated account creation) is handled by #658 and is not touched here.

## #42604 — cross-project task disclosure & modification

**`tasks`, `advanced/tasks`, `advanced/taskscsv`** run `Task::get_results()`, which only constrains by project when a `project_id` param is present. The one hook that could add a membership constraint, `wedevs_pm_task_where`, has no registered listener — so a subscriber belonging to no project read every project's tasks, their descriptions and the creators'/assignees' email addresses, and exported the same set as CSV.

- Added `where_membership()` to the query builder. Managers/admins query across projects as before; everyone else is bound to the projects they are a member of (a member of none matches nothing). Applied in the shared `where()` chain, so every caller of `get_results()` (tasks, advanced tasks, CSV, kanban) is covered. `projects/{project_id}/tasks` (`index`) already scopes by `project_id` on its own query and is unaffected.

**`projects/{project_id}/tasks/sorting`** accepted `list_id` / `task_id` / `orders[].id` from the body while checking only the project in the URL, so a member of one project could reorder and relocate another project's tasks.

- Now requires `Access_Project`, and binds every list/task id in the body to that `project_id` before mutating (rejects with 403 on mismatch).

## #43987 — any user's activity feed, tasks & email

**`users/{id}/user-activities`** and **`users/{id}/tasks`** used the `{id}` from the URL with no check that it is the caller, leaking the target's activity feed (with actor email) and task list (with the target's user object).

- New `Access_User` permission: a caller may read only their own resources; reading another user's requires a project-management capability. Applied to `user-activities`, `users/{id}/tasks`, and `users/{id}/tasks/calender`.
- `assigned_users` already scopes to the caller's projects and is left unchanged.

## The property

The named routes are the reported instances of one property: **every route in this namespace must constrain its query to the caller's projects, and bind any request-supplied id to the project it gated on.** `Access_Project` and the scoped `File_Controller::index` already follow it; this PR extends it to the task and per-user routes.

## Non-breaking

- **My Tasks** always requests the current user's id (`PM_Vars.current_user.ID`) → `Access_User` passes.
- Reports / advanced views are manager-facing; the manage capability bypasses the membership clause, so admins still see all tasks.
- Per-project managers are members in `pm_role_user`, so their own projects remain visible.

## Verification

- `php -l` clean on all changed files.
- No line-ending changes (Free plugin is CRLF; diff is content-only).

## Files

- `core/Permissions/Access_User.php` *(new)*
- `routes/mytask.php` — `user-activities` / `tasks` / `tasks/calender` → `Access_User`
- `routes/task.php` — `tasks/sorting` → `Access_Project`
- `src/Task/Helper/Task.php` — `where_membership()`
- `src/Task/Controllers/Task_Controller.php` — bind sorting ids to project
