### PR TITLE
fix(security): authz/IDOR hardening sweep — bind object ids, scope activity/search/settings, gate role CRUD (WP 7.1)

### DIFF
--- a/core/Permissions/Manager_Anywhere.php
+++ b/core/Permissions/Manager_Anywhere.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace WeDevs\PM\Core\Permissions;
+
+use WeDevs\PM\Core\Permissions\Abstract_Permission;
+
+/**
+ * Allow users who can manage projects globally OR hold the manager role
+ * (role_id = 1) in any project. Mirrors the front-end ManagerRoute /
+ * usePermissions().isManagerAnywhere, so project-scoped managers (with no
+ * global capability) keep access to global manager pages such as Sprints.
+ */
+class Manager_Anywhere extends Abstract_Permission {
+
+    public function check() {
+        if ( function_exists( 'wedevs_pm_current_user_is_manager_anywhere' )
+            && wedevs_pm_current_user_is_manager_anywhere() ) {
+            return true;
+        }
+
+        return new \WP_Error( 'manager', __( "You have no permission.", "wedevs-project-manager" ) );
+    }
+}

--- a/core/Sanitizer/Abstract_Sanitizer.php
+++ b/core/Sanitizer/Abstract_Sanitizer.php
@@ -20,7 +20,7 @@ abstract class Abstract_Sanitizer implements Sanitizer {
      */
     protected $sanitized_data = [];
 
-    public function __construct( WP_REST_Request $request = null ) {
+    public function __construct( ?WP_REST_Request $request = null ) {
         if ( $request ) {
             $this->request = $request;
         }

--- a/core/Validator/Abstract_Validator.php
+++ b/core/Validator/Abstract_Validator.php
@@ -20,7 +20,7 @@ abstract class Abstract_Validator implements Validator {
      */
     protected $errors = [];
 
-    public function __construct( WP_REST_Request $request = null ) {
+    public function __construct( ?WP_REST_Request $request = null ) {
         if ( $request ) {
             $this->request = $request;
         }

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Contributors: tareq1988, nizamuddinbabu, wedevs
 Donate Link: https://tareq.co/donate/
 Tags: kanban, project, project management, task management, project manager
 Requires at least: 6.2
-Tested up to: 7.0
+Tested up to: 7.1
 Requires PHP: 7.4
 Stable tag: 4.0.6
 License: GPLv2 or later

--- a/routes/role.php
+++ b/routes/role.php
@@ -11,14 +11,14 @@ $wedevs_pm_router = Router::singleton();
 $wedevs_pm_router->get( 'roles', 'WeDevs/PM/Role/Controllers/Role_Controller@index' )
 ->permission(['WeDevs\PM\Core\Permissions\Authentic']);
 $wedevs_pm_router->post( 'roles', 'WeDevs/PM/Role/Controllers/Role_Controller@store' )
-->permission(['WeDevs\PM\Core\Permissions\Project_Manage_Capability'])
+->permission(['WeDevs\PM\Core\Permissions\Settings_Page_Access'])
 ->validator( 'WeDevs\PM\Role\Validators\Create_Role' );
 
 $wedevs_pm_router->get( 'roles/{id}', 'WeDevs/PM/Role/Controllers/Role_Controller@show' )
 ->permission(['WeDevs\PM\Core\Permissions\Authentic']);
 $wedevs_pm_router->put( 'roles/{id}', 'WeDevs/PM/Role/Controllers/Role_Controller@update' )
-->permission(['WeDevs\PM\Core\Permissions\Project_Manage_Capability'])
+->permission(['WeDevs\PM\Core\Permissions\Settings_Page_Access'])
 ->validator( 'WeDevs\PM\Role\Validators\Update_Role' );
 
 $wedevs_pm_router->delete( 'roles/{id}', 'WeDevs/PM/Role/Controllers/Role_Controller@destroy' )
-->permission(['WeDevs\PM\Core\Permissions\Project_Manage_Capability']);
+->permission(['WeDevs\PM\Core\Permissions\Settings_Page_Access']);

--- a/src/Activity/Helper/Activity.php
+++ b/src/Activity/Helper/Activity.php
@@ -330,6 +330,7 @@ class Activity {
 		$this->where_id()
 			->where_actor_id()
 			->where_project_id()
+			->where_membership()
 			->where_resource_id()
 			->where_resource_type()
 			->where_updated_at();
@@ -513,6 +514,39 @@ class Activity {
 		if ( !is_array( $project_id ) ) {
 			$this->where .= $wpdb->prepare( " AND {$this->tb_activity}.project_id IN (%d)", $project_id );
 		}
+
+		return $this;
+	}
+
+	/**
+	 * Constrain activities to the projects the current user belongs to.
+	 * Managers/admins see all; everyone else only their member projects
+	 * (prevents the whole-site activity feed leaking to any logged-in user).
+	 */
+	private function where_membership() {
+		if ( wedevs_pm_user_can_access() ) {
+			return $this;
+		}
+
+		global $wpdb;
+		$user_id      = get_current_user_id();
+		$tb_role_user = esc_sql( wedevs_pm_tb_prefix() . 'pm_role_user' );
+
+		$project_ids = $wpdb->get_col( $wpdb->prepare(
+			"SELECT DISTINCT project_id FROM {$tb_role_user} WHERE user_id = %d",
+			$user_id
+		) );
+
+		$project_ids = array_map( 'absint', (array) $project_ids );
+
+		if ( empty( $project_ids ) ) {
+			$this->where .= ' AND 0 = 1';
+
+			return $this;
+		}
+
+		$format = implode( ',', array_fill( 0, count( $project_ids ), '%d' ) );
+		$this->where .= $wpdb->prepare( " AND {$this->tb_activity}.project_id IN ($format)", $project_ids );
 
 		return $this;
 	}

--- a/src/Comment/Controllers/Comment_Controller.php
+++ b/src/Comment/Controllers/Comment_Controller.php
@@ -64,8 +64,15 @@ class Comment_Controller {
     }
 
     public function show( WP_REST_Request $request ) {
-        $comment_id = $request->get_param( 'comment_id' );
-        $comment    = Comment::find( $comment_id );
+        $comment_id = intval( $request->get_param( 'comment_id' ) );
+        $project_id = intval( $request->get_param( 'project_id' ) );
+
+        // Bind the comment to the gated project (IDOR guard).
+        $comment = Comment::where( 'id', $comment_id )->where( 'project_id', $project_id )->first();
+
+        if ( ! $comment ) {
+            return new \WP_Error( 'pm_comment', __( 'Comment not found in this project.', 'wedevs-project-manager' ), [ 'status' => 404 ] );
+        }
         $resource   = new Item( $comment, new Comment_Transformer );
 
         return $this->get_response( $resource );
@@ -120,7 +127,14 @@ class Comment_Controller {
         // An array of file ids that needs to be deleted
         $files_to_delete = $request->get_param( 'files_to_delete' );
 
-        $comment = Comment::with('files')->find( $data['comment_id'] );
+        $project_id = intval( $request->get_param( 'project_id' ) );
+
+        // Bind the comment to the gated project (IDOR guard).
+        $comment = Comment::with('files')->where( 'id', intval( $data['comment_id'] ) )->where( 'project_id', $project_id )->first();
+
+        if ( ! $comment ) {
+            return new \WP_Error( 'pm_comment', __( 'Comment not found in this project.', 'wedevs-project-manager' ), [ 'status' => 404 ] );
+        }
 
         $comment->update( $data );
 
@@ -146,8 +160,15 @@ class Comment_Controller {
     }
 
     public function destroy( WP_REST_Request $request ) {
-        $comment_id = $request->get_param( 'comment_id' );
-        $comment    = Comment::find( $comment_id );
+        $comment_id = intval( $request->get_param( 'comment_id' ) );
+        $project_id = intval( $request->get_param( 'project_id' ) );
+
+        // Bind the comment to the gated project (IDOR guard).
+        $comment = Comment::where( 'id', $comment_id )->where( 'project_id', $project_id )->first();
+
+        if ( ! $comment ) {
+            wp_send_json_error( [ 'message' => __( 'Comment not found in this project.', 'wedevs-project-manager' ) ], 404 );
+        }
         
         $resource_type = $comment->commentable_type;
         $resource_id = $comment->commentable_id;

--- a/src/File/Controllers/File_Controller.php
+++ b/src/File/Controllers/File_Controller.php
@@ -45,8 +45,15 @@ class File_Controller {
     }
 
     public function show( WP_REST_Request $request ) {
-        $file_id = intval($request->get_param( 'file_id' ) );
-        $file = File::find( $file_id );
+        $file_id    = intval( $request->get_param( 'file_id' ) );
+        $project_id = intval( $request->get_param( 'project_id' ) );
+
+        // Bind the file to the gated project (IDOR guard).
+        $file = File::where( 'id', $file_id )->where( 'project_id', $project_id )->first();
+
+        if ( ! $file ) {
+            return new \WP_Error( 'pm_file', __( 'File not found in this project.', 'wedevs-project-manager' ), [ 'status' => 404 ] );
+        }
 
         $resource = new Item( $file, new File_Transformer );
 
@@ -69,9 +76,16 @@ class File_Controller {
     }
 
     public function rename( WP_REST_Request $request ) {
-        $file_id   = intval( $request->get_param( 'file_id' ) );
-        $file_name = sanitize_file_name($request->get_param( 'name' ) );
-        $file      = File::find( $file_id );
+        $file_id    = intval( $request->get_param( 'file_id' ) );
+        $project_id = intval( $request->get_param( 'project_id' ) );
+        $file_name  = sanitize_file_name( $request->get_param( 'name' ) );
+
+        // Bind the file to the gated project (IDOR guard).
+        $file = File::where( 'id', $file_id )->where( 'project_id', $project_id )->first();
+
+        if ( ! $file ) {
+            return new \WP_Error( 'pm_file', __( 'File not found in this project.', 'wedevs-project-manager' ), [ 'status' => 404 ] );
+        }
 
         File_System::update( $file->attachment_id, array( 'name' => $file_name ) );
 
@@ -81,9 +95,16 @@ class File_Controller {
     }
 
     public function destroy( WP_REST_Request $request ) {
-        $file_id = intval( $request->get_param( 'file_id' ) );
+        $file_id    = intval( $request->get_param( 'file_id' ) );
+        $project_id = intval( $request->get_param( 'project_id' ) );
 
-        $file = File::find( $file_id );
+        // Bind the file to the gated project (IDOR guard).
+        $file = File::where( 'id', $file_id )->where( 'project_id', $project_id )->first();
+
+        if ( ! $file ) {
+            wp_send_json_error( [ 'message' => __( 'File not found in this project.', 'wedevs-project-manager' ) ], 404 );
+        }
+
         File_System::delete( $file->attachment_id );
         $file->delete();
 
@@ -91,11 +112,27 @@ class File_Controller {
     }
 
     public function download( WP_REST_Request $request ) {
-        $file_id = intval( $request->get_param('file_id') );
+        $file_id    = intval( $request->get_param('file_id') );
+        $project_id = intval( $request->get_param( 'project_id' ) );
+
+        // Bind the requested id to a file in the gated project. The param may be
+        // the pm_files id or the WP attachment id; either way it must resolve to a
+        // row in THIS project (prevents streaming any attachment on the site).
+        $file_row = File::where( 'project_id', $project_id )
+            ->where( function( $query ) use ( $file_id ) {
+                $query->where( 'id', $file_id )->orWhere( 'attachment_id', $file_id );
+            } )->first();
+
+        if ( ! $file_row ) {
+            status_header( 404 );
+            die( esc_html__( 'file not found', 'wedevs-project-manager' ) );
+        }
+
+        $attachment_id = intval( $file_row->attachment_id );
 
         //get file path
-        $file = File_System::get_file( $file_id );
-        $path = get_attached_file( $file_id );
+        $file = File_System::get_file( $attachment_id );
+        $path = get_attached_file( $attachment_id );
 
         // Initialize WP_Filesystem
         global $wp_filesystem;

--- a/src/File/Helper/File.php
+++ b/src/File/Helper/File.php
@@ -76,7 +76,7 @@ class File {
     }
 
     public static function contains_xss_code( $content ) {
-		$pattern = '/<script.*?>.*?<\/script>|on[a-z]+\s*=\s*["\'][^"\']*["\']|javascript\s*[:=][^"\']+|data\s*[:=][^"\']+/ix';
+		$pattern = '/<script.*?>.*?<\/script>|on[a-z]+\s*=|javascript\s*[:=][^"\']+|data\s*[:=][^"\']+/ix';
         return preg_match($pattern, $content);
     }
 

--- a/src/Milestone/Controllers/Milestone_Controller.php
+++ b/src/Milestone/Controllers/Milestone_Controller.php
@@ -286,6 +286,12 @@ class Milestone_Controller {
         $milestone_id = intval( $request->get_param( 'milestone_id' ) );
         $task_id      = intval( $request->get_param( 'task_id' ) );
 
+        // Bind the milestone + task to the gated project (IDOR guard).
+        if ( ! Milestone::where( 'id', $milestone_id )->where( 'project_id', $project_id )->exists()
+            || ! \WeDevs\PM\Task\Models\Task::where( 'id', $task_id )->where( 'project_id', $project_id )->exists() ) {
+            return new \WP_Error( 'pm_milestone', __( 'Milestone or task not found in this project.', 'wedevs-project-manager' ), [ 'status' => 404 ] );
+        }
+
         Boardable::where( 'board_id', $milestone_id )
             ->where( 'board_type', 'milestone' )
             ->where( 'boardable_id', $task_id )
@@ -298,10 +304,17 @@ class Milestone_Controller {
     }
 
     public function privacy( WP_REST_Request $request ) {
-        $project_id = intval( $request->get_param( 'project_id' ) );
-        $milestone_id = $request->get_param( 'milestone_id' );
-        $privacy = $request->get_param( 'is_private' );
-        $milestone = Milestone::find( $milestone_id );
+        $project_id   = intval( $request->get_param( 'project_id' ) );
+        $milestone_id = intval( $request->get_param( 'milestone_id' ) );
+        $privacy      = (int) filter_var( $request->get_param( 'is_private' ), FILTER_VALIDATE_BOOLEAN );
+
+        // Bind the milestone to the gated project (IDOR guard).
+        $milestone = Milestone::where( 'id', $milestone_id )->where( 'project_id', $project_id )->first();
+
+        if ( ! $milestone ) {
+            return new \WP_Error( 'pm_milestone', __( 'Milestone not found in this project.', 'wedevs-project-manager' ), [ 'status' => 404 ] );
+        }
+
         $milestone->update_model( [
             'is_private' => $privacy
         ] );

--- a/src/Search/Controllers/Search_Controller.php
+++ b/src/Search/Controllers/Search_Controller.php
@@ -28,6 +28,10 @@ class Search_Controller {
 		}
 
     	if ( $project_id || !empty( $model ) ) {
+    		// A supplied project_id must be one the caller can access.
+    		if ( $project_id && ! wedevs_pm_user_can( 'view_project', $project_id ) ) {
+    			return new \WP_Error( 'pm_search', __( 'You have no permission.', 'wedevs-project-manager' ), [ 'status' => 403 ] );
+    		}
     		return $this->get_result_for_project( $string, $project_id, $model );
     	}
     	return $this->get_all_result( $string );

--- a/src/Settings/Controllers/Settings_Controller.php
+++ b/src/Settings/Controllers/Settings_Controller.php
@@ -21,6 +21,11 @@ class Settings_Controller {
         $project_id = intval( $request->get_param( 'project_id' ) );
         $key        = $request->get_param( 'key' );
 
+        // A supplied project_id must be one the caller can access (IDOR guard).
+        if ( $project_id && ! wedevs_pm_user_can( 'view_project', $project_id ) ) {
+            return new \WP_Error( 'pm_settings', __( 'You have no permission.', 'wedevs-project-manager' ), [ 'status' => 403 ] );
+        }
+
         if ( $project_id && $key ) {
             $settings = Settings::where( 'project_id', $project_id )
                 ->where( 'key', $key )

--- a/src/Task/Controllers/Task_Controller.php
+++ b/src/Task/Controllers/Task_Controller.php
@@ -94,6 +94,12 @@ class Task_Controller {
     public function show( WP_REST_Request $request ) {
         $project_id = intval( $request->get_param( 'project_id' ) );
         $task_id    = intval( $request->get_param( 'task_id' ) );
+
+        // Bind the task to the gated project (IDOR guard).
+        if ( ! Task::where( 'id', $task_id )->where( 'project_id', $project_id )->exists() ) {
+            return new \WP_Error( 'pm_task', __( 'Task not found in this project.', 'wedevs-project-manager' ), [ 'status' => 404 ] );
+        }
+
         return $this->get_task( $task_id, $project_id, $request->get_params() );
     }
 
@@ -328,6 +334,13 @@ class Task_Controller {
     }
 
     public function update( WP_REST_Request $request ) {
+        $project_id = intval( $request->get_param( 'project_id' ) );
+        $task_id    = intval( $request->get_param( 'task_id' ) );
+
+        // Bind the task to the gated project (IDOR guard).
+        if ( ! Task::where( 'id', $task_id )->where( 'project_id', $project_id )->exists() ) {
+            return new \WP_Error( 'pm_task', __( 'Task not found in this project.', 'wedevs-project-manager' ), [ 'status' => 404 ] );
+        }
 
         return $this->task_update( $request->get_params() );
     }
@@ -395,7 +408,14 @@ class Task_Controller {
     }
 
     public function change_status( WP_REST_Request $request ) {
+        $project_id   = intval( $request->get_param( 'project_id' ) );
         $task_id      = $request->get_param( 'task_id' );
+
+        // Bind the task to the gated project (IDOR guard).
+        if ( ! Task::where( 'id', $task_id )->where( 'project_id', $project_id )->exists() ) {
+            return new \WP_Error( 'pm_task', __( 'Task not found in this project.', 'wedevs-project-manager' ), [ 'status' => 404 ] );
+        }
+
         $task         = Task::with('assignees')->find( $task_id );
         $status       = $request->get_param( 'status' );
         $old_value    = $task->status;
@@ -561,11 +581,17 @@ class Task_Controller {
     }
 
     public function attach_to_board( WP_REST_Request $request ) {
+        $project_id = intval( $request->get_param( 'project_id' ) );
         $task_id  = $request->get_param( 'task_id' );
         $board_id = $request->get_param( 'board_id' );
 
-        $task  = Task::find( $task_id );
-        $board = Board::find( $board_id );
+        // Bind task + board to the gated project (IDOR guard).
+        $task  = Task::where( 'id', $task_id )->where( 'project_id', $project_id )->first();
+        $board = Board::where( 'id', $board_id )->where( 'project_id', $project_id )->first();
+
+        if ( ! $task || ! $board ) {
+            return new \WP_Error( 'pm_task', __( 'Task or board not found in this project.', 'wedevs-project-manager' ), [ 'status' => 404 ] );
+        }
 
         $latest_order = Boardable::latest_order( $board->id, $board->type, 'task' );
         $boardable    = Boardable::firstOrCreate([
@@ -582,11 +608,17 @@ class Task_Controller {
     }
 
     public function detach_from_board( WP_REST_Request $request ) {
+        $project_id = intval( $request->get_param( 'project_id' ) );
         $task_id  = $request->get_param( 'task_id' );
         $board_id = $request->get_param( 'board_id' );
 
-        $task  = Task::find( $task_id );
-        $board = Board::find( $board_id );
+        // Bind task + board to the gated project (IDOR guard).
+        $task  = Task::where( 'id', $task_id )->where( 'project_id', $project_id )->first();
+        $board = Board::where( 'id', $board_id )->where( 'project_id', $project_id )->first();
+
+        if ( ! $task || ! $board ) {
+            return new \WP_Error( 'pm_task', __( 'Task or board not found in this project.', 'wedevs-project-manager' ), [ 'status' => 404 ] );
+        }
 
         $boardable = Boardable::where( 'board_id', $board->id )
             ->where( 'board_type', $board->type )
@@ -664,9 +696,16 @@ class Task_Controller {
 
     public function privacy( WP_REST_Request $request ) {
         $project_id = intval( $request->get_param( 'project_id' ) );
-        $task_id = $request->get_param( 'task_id' );
-        $privacy = $request->get_param( 'is_private' );
-        $task = Task::find( $task_id );
+        $task_id    = intval( $request->get_param( 'task_id' ) );
+        $privacy    = (int) filter_var( $request->get_param( 'is_private' ), FILTER_VALIDATE_BOOLEAN );
+
+        // Bind the task to the gated project (IDOR guard).
+        $task = Task::where( 'id', $task_id )->where( 'project_id', $project_id )->first();
+
+        if ( ! $task ) {
+            return new \WP_Error( 'pm_task', __( 'Task not found in this project.', 'wedevs-project-manager' ), [ 'status' => 404 ] );
+        }
+
         $task->update_model( [
             'is_private' => $privacy
         ] );
@@ -935,6 +974,13 @@ class Task_Controller {
 
         $current_page = intval( $request->get_param( 'activityPage' ) );
         $task_id = intval( $request->get_param( 'task_id' ) );
+        $project_id = intval( $request->get_param( 'project_id' ) );
+
+        // Bind the task to the gated project (IDOR guard).
+        if ( ! Task::where( 'id', $task_id )->where( 'project_id', $project_id )->exists() ) {
+            return new \WP_Error( 'pm_task', __( 'Task not found in this project.', 'wedevs-project-manager' ), [ 'status' => 404 ] );
+        }
+
 
         $per_page = 10;
 


### PR DESCRIPTION
Hardens the Free plugin against the authorization/IDOR class the 2026-08-19 audit surfaced (tracking: weDevsOfficial/plugin-internal-tasks#7 §5). Base `develop`. Ships in the security release (Free v4.0.7). PoC-verified on `we-pm.test`.

## IDOR — bind object ids to the gated project (`pm-pro#462`)
Object-level permission classes gate on the request `project_id` but the handlers then fetched/mutated a different object by a request id with no binding. Every `find()` by a request id is now `where('id',$id)->where('project_id',$project_id)` (404 on miss), matching the already-correct `destroy()`/`attach_users()`:
- `File_Controller`: `show`/`rename`/`destroy` bound; **`download()`** resolves the attachment through a project-bound `pm_files` row (id **or** attachment_id) instead of streaming `get_attached_file($file_id)` for any id (was: any WP attachment on the site).
- `Task_Controller`: `show`/`update`/`change_status`/`attach_to_board`/`detach_from_board`/`privacy`/`activities` bound (board_id too); `privacy` int-casts `is_private`.
- `Comment_Controller`: `show`/`update`/`destroy` bound.
- `Milestone_Controller`: `privacy`/`detach_task` bound; `privacy` int-casts.

## Route authorization (`pm-pro#463`)
- **`GET activities`** returned the whole site's activity feed to any logged-in user — added `where_membership()` to the Activity query builder (managers see all, everyone else only their member projects).
- **Search** + **Settings::index** returned another project's data when a `project_id` was supplied — both now require `wedevs_pm_user_can('view_project', project_id)`.

## Privilege escalation (`pm-pro#464`)
`routes/role.php` store/update/destroy mutate the **global** `pm_roles` table but were gated by per-project `Project_Manage_Capability`, so a single-project manager could delete/alter site-wide role definitions. Now require `Settings_Page_Access` (admin capability). The UI only calls `roles` GET.

## Compat + defense-in-depth (`pm-pro#468`, `pm-pro#469`)
- `readme.txt` Tested up to **7.1** (ships today).
- `core/Validator` + `core/Sanitizer` Abstract_*: `?WP_REST_Request` (PHP 8.4 deprecation).
- `File::contains_xss_code`: match `on[a-z]+=` so an unquoted SVG event handler no longer bypasses the check.

## Verification
- `php -l` clean on every changed file; CRLF preserved (content-only diff).
- Task `show`: own-project **200**, cross-project **404**; non-member activity feed scoped; role CRUD denied to non-admins.

Refs weDevsOfficial/pm-pro#462 #463 #464 #468 #469 (free portion — pro handled in the sibling pm-pro PR; issues close when both merge).
