### PR TITLE
Fix Undefined offset notice for priority 3 (Urgent) in Task::priorities()

### DIFF
--- a/src/Task/Helper/Task.php
+++ b/src/Task/Helper/Task.php
@@ -385,9 +385,10 @@ class Task {
         	0 => 'low',
 	        1 => 'medium',
 	        2 => 'high',
+	        3 => 'urgent',
 	    ];
 
-	    return $items[$priorities];
+	    return isset( $items[$priorities] ) ? $items[$priorities] : 'low';
     }
 
     public static function status( $status ) {


### PR DESCRIPTION
## What

Map priority `3` (Urgent) in `Task::priorities()` and default unknown keys, so the helper never emits an `Undefined offset` notice.

## Why

`Task::priorities()` mapped only `0/1/2` (`low`/`medium`/`high`), but the app supports a 4th level — **Urgent** (`priority >= 3`, see `views/assets/src/components/tasks/TaskRow.jsx:216`). Tasks with `priority = 3` hit `$items[$priorities]` with a missing key:

```
Notice: Undefined offset: 3 in src/Task/Helper/Task.php on line 390
```

With `WP_DEBUG_DISPLAY` on, that notice HTML is prepended to REST JSON responses that transform such tasks (e.g. the **Sprint list** task include, `GET pm-pro/v2/sprints?with=…,incomplete_tasks,complete_tasks`), breaking `JSON.parse` on the client and rendering an empty Sprint list.

## Change

```php
-        $items = [
-            0 => 'low',
-            1 => 'medium',
-            2 => 'high',
-        ];
-        return $items[$priorities];
+        $items = [
+            0 => 'low',
+            1 => 'medium',
+            2 => 'high',
+            3 => 'urgent',
+        ];
+        return isset( $items[$priorities] ) ? $items[$priorities] : 'low';
```

One file, `src/Task/Helper/Task.php` (+2 / -1).

## Testing

- Verified the polluted response before the fix (leading `<br /><b>Notice</b>…`) and clean valid JSON after.
- Sprint list renders again (All Projects: 4 sprints; single project: 3), Kanban board unaffected, console clean.

Closes weDevsOfficial/pm-pro#471
