### PR TITLE
Fix Kanban Import Task: show every task list, filter tasks by the selected list

### DIFF
--- a/src/Task_List/Controllers/Task_List_Controller.php
+++ b/src/Task_List/Controllers/Task_List_Controller.php
@@ -132,7 +132,13 @@ class Task_List_Controller {
         $task_lists = apply_filters( "wedevs_pm_task_list_check_privacy", $task_lists, $project_id, $request );
 
         if ( $per_page == '-1' ) {
-            $per_page = $task_lists->count();
+            // The query groups by board id, and count() on a grouped query
+            // returns the row count of the first group rather than the number
+            // of groups. That produced an arbitrary page size -- as small as 1
+            // when the first list had a single task -- which silently clipped
+            // the response. getCountForPagination() counts the groups.
+            $per_page = $task_lists->toBase()->getCountForPagination();
+            $per_page = $per_page > 0 ? $per_page : 1;
         }
 
         $task_lists = $task_lists->orderBy( $tb_lists. '.order', 'DESC' )

--- a/views/assets/src/components/KanbanBoard/parts/ImportTaskModal.jsx
+++ b/views/assets/src/components/KanbanBoard/parts/ImportTaskModal.jsx
@@ -58,7 +58,10 @@ export default function ImportTaskModal({ open, onOpenChange, projectId, boardId
     api
       .get("tasks", {
         project_id: projectId,
-        task_list_id: [selectedList],
+        // The tasks endpoint filters on `lists`; `task_list_id` is not a
+        // parameter it reads, so sending that returned every task in the
+        // project regardless of the list picked.
+        lists: [selectedList],
         per_page: -1,
       })
       .then((res) => {


### PR DESCRIPTION
Fixes the Kanban **Import Task** dialog, which showed only some of a project's task lists and then ignored which list you picked.

Closes weDevsOfficial/pm-pro#472

Two independent faults. Both fail silently — the API returns a plausible response rather than an error, which is why they read as one bug.

### 1. Only some task lists appear

`Task_List_Controller::index()` builds the list query with `groupBy(pm_boards.id)` plus leftJoins to `pm_boardables` and `pm_meta`, then resolved `per_page=-1` with `$task_lists->count()`.

On a grouped query Eloquent emits `SELECT count(*) … GROUP BY`, gets one row per group and takes the first — so the page size is the row count of the **first group**, not the number of lists.

Measured before the fix, across eight projects:

| project | resolved per_page | actual lists |
|---|---|---|
| 18 | 21 | 4 |
| 2 | 29 | 3 |
| 3 | 8 | 5 |
| 4 | 18 | 5 |
| 5 | 10 | 5 |
| 6 | 17 | 5 |
| 7 | 33 | 3 |
| 8 | 11 | 5 |

Never the list count. Whenever that number falls below the number of lists the response is clipped, and a project whose first list holds a single task resolves to a page size of **1** — the one-list dropdown in the report.

`getCountForPagination()` special-cases `isset($this->groups)` and counts the groups, which is what this branch wants.

### 2. The selected list does not filter the tasks

The modal sent `task_list_id`, but the tasks endpoint (`Task\Helper\Task::where_lists()`) reads `lists`. An unrecognised parameter is ignored outright, so every task in the project came back regardless of the list picked.

Before the fix, two different lists returned byte-identical ids:

```
list 194 (In Review) → 50 tasks, first ids [1192,1193,1194,1197,1198]
list 192 (To Do)     → 50 tasks, first ids [1192,1193,1194,1197,1198]
identical: true
```

50 was simply every task in the project.

### Verification

```
per_page for per_page=-1 : 4/4, 5/5, 3/3        (was 21, 8, 33)
tasks per list (proj 18) : In Review 11, In Progress 13, To Do 13, Backlog 13  → 50 total
```

The per-list counts now sum to the project total instead of each returning all 50. Confirmed in the UI as well: the dropdown lists all four lists, and switching between them swaps the task set.

### Scope

Kanban lives in the Free plugin and the list endpoint is Free's, so the fix lands here; the issue stays on pm-pro as the tracking record.

Found but deliberately not changed: the list query defaults to `status = [1]` when no status is sent, so a list in any other status never appears in the dropdown. That is existing product-wide behaviour, not specific to this modal.
