### PR TITLE
Fix AI models never loading for OpenAI/Google (empty model dropdown)

### DIFF
--- a/src/Settings/Controllers/AI_Settings_Controller.php
+++ b/src/Settings/Controllers/AI_Settings_Controller.php
@@ -84,18 +84,26 @@ class AI_Settings_Controller {
         // Get models
         $models = self::get_models();
 
-        // If we have an API key but no cache, try to fetch models in the background
+        // If the selected provider has a key but no models yet (e.g. the key was
+        // added after the cache was first built for another provider), refresh
+        // so its models actually appear.
         if ( $provider && isset( $api_key_setting ) && !empty( $api_key_setting->value ) ) {
-            $cached_models = get_transient( 'pm_ai_models_cache' );
-            if ( empty( $cached_models ) || !isset( $cached_models['models'] ) || empty( $cached_models['models'] ) ) {
-                // Trigger model update in background (non-blocking)
-                // Use a transient flag to prevent multiple simultaneous fetches
+            $has_provider_models = false;
+            foreach ( $models as $model_config ) {
+                if ( isset( $model_config['provider'] ) && $model_config['provider'] === $provider ) {
+                    $has_provider_models = true;
+                    break;
+                }
+            }
+
+            if ( ! $has_provider_models ) {
                 $fetch_lock = get_transient( 'pm_ai_models_fetching' );
                 if ( !$fetch_lock ) {
                     set_transient( 'pm_ai_models_fetching', true, 60 ); // Lock for 60 seconds
-                    // Schedule the fetch (non-blocking)
+                    AI_Config::clear_models_cache();
                     AI_Config::update_all_models();
                     delete_transient( 'pm_ai_models_fetching' );
+                    $models = self::get_models(); // re-read with the fresh cache
                 }
             }
         }
@@ -191,11 +199,14 @@ class AI_Settings_Controller {
 
         do_action( 'wedevs_pm_after_save_settings', $settings );
 
-        // Update models cache if API key was saved
+        // Update models cache if an API key was saved. Incoming keys are the
+        // literal 'ai_api_key' (provider suffix is added later), so match the
+        // 'ai_api_key' prefix — matching 'ai_api_key_' misses every save.
         if ( is_array( $settings_data ) ) {
             foreach ( $settings_data as $setting_item ) {
-                if ( isset( $setting_item['key'] ) && strpos( $setting_item['key'], 'ai_api_key_' ) === 0 ) {
-                    // API key was saved, refresh models cache
+                if ( isset( $setting_item['key'] ) && strpos( $setting_item['key'], 'ai_api_key' ) === 0 ) {
+                    // API key was saved — rebuild the models cache from scratch.
+                    AI_Config::clear_models_cache();
                     AI_Config::update_all_models();
                     break;
                 }


### PR DESCRIPTION
## What

Fixes the AI Settings "**No models available for this provider**" bug for OpenAI/Google, where the Model dropdown never appears even with a valid, connection-tested API key.

## Root cause (backend only)

Model list is cached in the `pm_ai_models_cache` transient (24h). Anthropic ships a static, always-present list, which exposed two defects:

1. **`index()` never refetched a missing provider** — the guard `empty($cached_models['models'])` was never true once anthropic was cached, so OpenAI/Google were never re-fetched for the whole cache lifetime. One network blip on the first fetch poisoned the provider for 24h.
2. **`store()` never busted the cache on API-key save** — the incoming key is the literal `ai_api_key` (provider suffix added later), but the guard matched `ai_api_key_` (trailing `_`), so it never fired.

## Fix

- `index()`: refetch when the **selected provider** has no models, then re-read `$models` so the fresh list ships in the same response.
- `store()`: match `ai_api_key` and **clear** the cache before rebuild, so saving a key busts it.

## Verification (runtime, local)

- Anthropic-only stale cache → single `GET /pm/v2/settings/ai?provider=openai` now refetches → `openai: 102` (was `[]`).
- `store()` with an `ai_api_key` → cache busted + rebuilt → `openai: 0 → 102`.
- AI project generation end-to-end on OpenAI: created a 9-list / 72-task project from the AI generator.
- PHP lint clean; frontend unchanged (it already rendered whatever the backend returned).

`ui-modernization` already carries the equivalent change; this ports it to `develop`.

Closes weDevsOfficial/pm-pro#474

https://claude.ai/code/session_01PsKkoH3J6MwAvEBgd7aUvG
