### PR TITLE
Fix Kanban drag announcing 'undefined' column to screen readers

### DIFF
--- a/views/assets/src/components/kanban/index.jsx
+++ b/views/assets/src/components/kanban/index.jsx
@@ -268,6 +268,18 @@ export const KanbanProvider = ({
     onDataChange?.(newData);
   };
 
+  // Resolve a column's display name. A drag `over` target can be the column
+  // droppable OR a card inside it — when it's a card, fall back to that card's
+  // column id so announcements never read "undefined".
+  const columnName = (id) => columns.find((c) => c.id === id)?.name;
+  const resolveOverColumnName = (over) => {
+    if (!over) return undefined;
+    const direct = columnName(over.id);
+    if (direct) return direct;
+    const overCard = data.find((item) => item.id === over.id);
+    return overCard ? columnName(overCard.column) : undefined;
+  };
+
   const announcements = {
     onDragStart({ active }) {
       if (active.data?.current?.type === "column") {
@@ -275,12 +287,13 @@ export const KanbanProvider = ({
         return `Picked up the column "${col?.name}"`;
       }
       const { name, column } = data.find((item) => item.id === active.id) ?? {};
-      return `Picked up the card "${name}" from the "${column}" column`;
+      return `Picked up the card "${name}" from the "${columnName(column) ?? ""}" column`;
     },
     onDragOver({ active, over }) {
       if (active.data?.current?.type === "column") return "";
       const { name } = data.find((item) => item.id === active.id) ?? {};
-      const newColumn = columns.find((column) => column.id === over?.id)?.name;
+      const newColumn = resolveOverColumnName(over);
+      if (!newColumn) return "";
       return `Dragged the card "${name}" over the "${newColumn}" column`;
     },
     onDragEnd({ active, over }) {
@@ -288,9 +301,9 @@ export const KanbanProvider = ({
         const col = columns.find((c) => c.id === active.id);
         return `Dropped the column "${col?.name}"`;
       }
-      const { name } = data.find((item) => item.id === active.id) ?? {};
-      const newColumn = columns.find((column) => column.id === over?.id)?.name;
-      return `Dropped the card "${name}" into the "${newColumn}" column`;
+      const activeItem = data.find((item) => item.id === active.id) ?? {};
+      const newColumn = resolveOverColumnName(over) ?? columnName(activeItem.column);
+      return `Dropped the card "${activeItem.name}" into the "${newColumn ?? ""}" column`;
     },
     onDragCancel({ active }) {
       if (active.data?.current?.type === "column") {


### PR DESCRIPTION
## What
Fixes the Kanban board announcing *"…into the **undefined** column"* to screen readers when a card is dropped onto another card.

## Root cause
`kanban/index.jsx` resolved the target column via `columns.find(c => c.id === over.id)` — but `over.id` is a **card** id when hovering a card, so the lookup was `undefined`. `onDragStart` also used the column **id** instead of its name.

## Fix
`resolveOverColumnName(over)` — column when `over.id` is a column, else the hovered card's `column` id → name. `onDragStart` resolves the source column name; `onDragOver` stays silent instead of announcing "undefined".

## Verification (browser)
Drag a card onto a card in another column → live region reads *Dragged/Dropped the card "…" over/into the "Backlog" column*.

Closes weDevsOfficial/pm-pro#475

https://claude.ai/code/session_01PsKkoH3J6MwAvEBgd7aUvG
