### PR TITLE
Hide Modules nav item from non-admins

### DIFF
--- a/views/assets/src/components/layout/AppSidebar.jsx
+++ b/views/assets/src/components/layout/AppSidebar.jsx
@@ -540,8 +540,8 @@ export function AppSidebar() {
             {viewNavItems.map(renderNavItem)}
           </div>
 
-          {/* Modules + Premium */}
-          {!isFrontend && (
+          {/* Modules + Premium (admin-only: module management is a site-admin action) */}
+          {!isFrontend && isAdmin && (
           <div className="mb-3">
             {!collapsed ? (
               <p className="text-[14px] font-medium text-pm-text-muted uppercase tracking-wider px-2 mb-1.5">


### PR DESCRIPTION
## What
Hides the sidebar **"Modules"** nav item from non-admin users. It was shown to Co-Workers even though the Modules page denies them ("Access denied").

## Root cause
`AppSidebar.jsx` — the "Modules + Premium" section was gated only on `!isFrontend`; the sibling "Administration" section is gated on `isAdmin`.

## Fix
Gate the Modules section on `isAdmin` (module management is a site-admin action).

## Verification (browser)
Co-Worker (project member): Modules nav gone; `/modules` still denies. Admin: unchanged.

Closes weDevsOfficial/pm-pro#476

https://claude.ai/code/session_01PsKkoH3J6MwAvEBgd7aUvG
