### PR TITLE
Fix stale task sheet data on hosts that cache wp-json, and project switching with a sheet open

### DIFF
--- a/core/Router/WP_Router.php
+++ b/core/Router/WP_Router.php
@@ -34,6 +34,49 @@ class WP_Router {
         // out of the JSON body — they would otherwise corrupt REST responses when
         // display_errors is on. Errors are still logged; only display is silenced.
         add_filter( 'rest_pre_dispatch', array( __CLASS__, 'silence_error_display' ), 10, 3 );
+
+        // Mark plugin REST responses as uncacheable. Without this, a host or CDN
+        // that rewrites Cache-Control on wp-json (e.g. an nginx `expires 1h` rule)
+        // makes browsers replay stale JSON, so the UI keeps showing old data.
+        add_filter( 'rest_post_dispatch', array( __CLASS__, 'send_nocache_headers' ), 10, 3 );
+	}
+
+	/**
+	 * Send no-store cache headers for this plugin's REST responses.
+	 *
+	 * @param  \WP_HTTP_Response $response
+	 * @param  \WP_REST_Server   $server
+	 * @param  \WP_REST_Request  $request
+	 *
+	 * @return \WP_HTTP_Response
+	 */
+	public static function send_nocache_headers( $response, $server, $request ) {
+		if ( ! is_object( $request ) || ! is_object( $response ) || ! method_exists( $response, 'header' ) ) {
+			return $response;
+		}
+
+		if ( ! self::is_plugin_route( $request ) ) {
+			return $response;
+		}
+
+		$response->header( 'Cache-Control', 'no-store, no-cache, must-revalidate, max-age=0' );
+		$response->header( 'Expires', 'Wed, 11 Jan 1984 05:00:00 GMT' );
+
+		return $response;
+	}
+
+	/**
+	 * Whether the request targets this plugin's REST namespace.
+	 *
+	 * @param  \WP_REST_Request $request
+	 *
+	 * @return bool
+	 */
+	private static function is_plugin_route( $request ) {
+		$namespace = wedevs_pm_api_namespace();
+		$route     = ltrim( (string) $request->get_route(), '/' );
+
+		return $route === $namespace || strpos( $route, $namespace . '/' ) === 0;
 	}
 
 	/**
@@ -51,11 +94,8 @@ class WP_Router {
 			return $result;
 		}
 
-		$namespace = wedevs_pm_api_namespace();
-		$route     = ltrim( (string) $request->get_route(), '/' );
-
 		// Exact namespace or a sub-route of it — avoids matching unrelated prefixes (pm/v2 vs pm/v20).
-		if ( $route === $namespace || strpos( $route, $namespace . '/' ) === 0 ) {
+		if ( self::is_plugin_route( $request ) ) {
 			static $logged = false;
 
 			if ( ini_set( 'display_errors', '0' ) === false && ! $logged ) {

--- a/views/assets/src/components/kanban/index.jsx
+++ b/views/assets/src/components/kanban/index.jsx
@@ -268,6 +268,15 @@ export const KanbanProvider = ({
     onDataChange?.(newData);
   };
 
+  // `over.id` is a card id when the card is dropped on another card, so the
+  // column has to be resolved through that card, the way handleDragOver does.
+  const resolveColumnName = (overId) => {
+    if (overId === undefined || overId === null) return undefined;
+    const overItem = data.find((item) => item.id === overId);
+    const columnId = overItem?.column ?? overId;
+    return columns.find((column) => column.id === columnId)?.name;
+  };
+
   const announcements = {
     onDragStart({ active }) {
       if (active.data?.current?.type === "column") {
@@ -280,7 +289,7 @@ export const KanbanProvider = ({
     onDragOver({ active, over }) {
       if (active.data?.current?.type === "column") return "";
       const { name } = data.find((item) => item.id === active.id) ?? {};
-      const newColumn = columns.find((column) => column.id === over?.id)?.name;
+      const newColumn = resolveColumnName(over?.id);
       return `Dragged the card "${name}" over the "${newColumn}" column`;
     },
     onDragEnd({ active, over }) {
@@ -289,7 +298,7 @@ export const KanbanProvider = ({
         return `Dropped the column "${col?.name}"`;
       }
       const { name } = data.find((item) => item.id === active.id) ?? {};
-      const newColumn = columns.find((column) => column.id === over?.id)?.name;
+      const newColumn = resolveColumnName(over?.id);
       return `Dropped the card "${name}" into the "${newColumn}" column`;
     },
     onDragCancel({ active }) {

--- a/views/assets/src/components/projects/FilesPage/utils.js
+++ b/views/assets/src/components/projects/FilesPage/utils.js
@@ -91,6 +91,7 @@ export async function checkPermissionAndDownload(permissionUrl, downloadUrl, __)
     const res = await fetch(permissionUrl, {
       method: "GET",
       credentials: "same-origin",
+      cache: "no-store",
       headers: {
         "Content-Type": "application/json",
         "X-WP-Nonce": (typeof PM_Vars !== "undefined" && PM_Vars.permission) || "",

--- a/views/assets/src/components/tasks/TaskDetailSheet/index.jsx
+++ b/views/assets/src/components/tasks/TaskDetailSheet/index.jsx
@@ -191,6 +191,15 @@ export default function TaskDetailSheet() {
 
     if (!taskId || !pid) return
 
+    // Navigating to another project while a sheet is open: close it instead of
+    // rewriting the URL back to the open task's project, which used to bounce
+    // the user into the previously visited project.
+    const onOtherProjectMatch = location.pathname.match(/^\/projects\/(\d+)(?:\/|$)/)
+    if (onOtherProjectMatch && String(onOtherProjectMatch[1]) !== String(pid)) {
+      dispatch(closeTaskSheet())
+      return
+    }
+
     const onSingleListMatch = location.pathname.match(/^\/projects\/(\d+)\/task-lists\/(\d+)(?:\/|$)/)
     const onTaskListsOverview = /^\/projects\/(\d+)\/task-lists(?:\/|$)/.test(location.pathname) && !onSingleListMatch
     const onKanbanMatch = location.pathname.match(/^\/projects\/(\d+)\/kanban(?:\/|$)/)

--- a/views/assets/src/hooks/useApi.js
+++ b/views/assets/src/hooks/useApi.js
@@ -45,9 +45,13 @@ async function request(method, endpoint, data) {
     ...(data && typeof data === 'object' ? data : {}),
   }
 
+  // no-store: some hosts/CDNs rewrite Cache-Control on wp-json responses
+  // (e.g. `max-age=3600`), which makes the browser replay stale JSON and the
+  // UI show outdated data until the cache expires.
   const options = {
     method,
     credentials: 'same-origin',
+    cache: 'no-store',
     headers: {
       'X-WP-Nonce': PM_Vars.permission,
     },
@@ -96,6 +100,7 @@ async function uploadFormData(endpoint, formData) {
   const options = {
     method: 'POST',
     credentials: 'same-origin',
+    cache: 'no-store',
     headers: {
       'X-WP-Nonce': PM_Vars.permission,
       // Do NOT set Content-Type — browser sets it with multipart boundary

--- a/views/assets/src/hooks/useProApi.js
+++ b/views/assets/src/hooks/useProApi.js
@@ -37,9 +37,12 @@ async function request(method, endpoint, data) {
     ...(data && typeof data === 'object' ? data : {}),
   }
 
+  // no-store: hosts/CDNs that rewrite Cache-Control on wp-json responses
+  // otherwise make the browser replay stale JSON for the whole max-age window.
   const options = {
     method,
     credentials: 'same-origin',
+    cache: 'no-store',
     headers: {
       'X-WP-Nonce': PM_Vars.permission,
     },
@@ -85,6 +88,7 @@ async function uploadFormData(endpoint, formData) {
     res = await fetch(url, {
       method: 'POST',
       credentials: 'same-origin',
+      cache: 'no-store',
       headers: { 'X-WP-Nonce': PM_Vars.permission },
       body: formData,
     })

--- a/views/assets/src/store/kanbanSlice.js
+++ b/views/assets/src/store/kanbanSlice.js
@@ -186,6 +186,16 @@ export const importTasks = createAsyncThunk(
   },
 )
 
+function adjustBoardTotals(board, delta) {
+  const pagination = board.tasksMeta?.pagination
+  if (!pagination) return
+  for (const key of ['total', 'count']) {
+    if (pagination[key] === undefined || pagination[key] === null) continue
+    const next = parseInt(pagination[key], 10) + delta
+    pagination[key] = Number.isNaN(next) ? pagination[key] : Math.max(next, 0)
+  }
+}
+
 const kanbanSlice = createSlice({
   name: 'kanban',
   initialState,
@@ -208,6 +218,10 @@ const kanbanSlice = createSlice({
       const [task] = tasks.splice(taskIndex, 1)
       const toTasks = toBoard.tasks?.data ?? toBoard.tasks ?? []
       toTasks.push(task)
+      // The column header reads pagination.total, so without this the counts
+      // stay on the fetched numbers until the board is loaded again.
+      adjustBoardTotals(fromBoard, -1)
+      adjustBoardTotals(toBoard, 1)
     },
     resetKanban() { return initialState },
   },

--- a/views/assets/src/store/settingsSlice.js
+++ b/views/assets/src/store/settingsSlice.js
@@ -66,6 +66,7 @@ export const loadAiSettings = createAsyncThunk(
       const res = await fetch(base, {
         method: 'GET',
         credentials: 'same-origin',
+        cache: 'no-store',
         headers: { 'X-WP-Nonce': PM_Vars.permission },
         signal,
       })


### PR DESCRIPTION
body built
s fixes

Three bugs found while testing the task detail sheet and Kanban board on the live FlyWP demo site.

### 1. Stale UI when the host caches wp-json responses

Closes weDevsOfficial/pm-pro#493

On that install every REST GET came back with `cache-control: max-age=3600`, so the browser replayed cached JSON for an hour. In the task sheet, Sprint stayed `None`, the label badge never appeared, Assignees stayed `Add` (and Estimate then said "no assignee"), and the wrong value survived close/reopen and even a full page reload, while the server had the correct data the whole time.

Proof it was the HTTP cache, same URL and session:

| request | assignees | labels |
|---|---|---|
| default fetch | `[]` | `[]` |
| `cache: 'no-store'` | `["1"]` | `["QA-RT"]` |

Fix:

- `useApi`, `useProApi` and the remaining raw GET call sites (`FilesPage/utils.js`, `settingsSlice.js`) send `cache: 'no-store'`.
- `WP_Router` marks `pm/v2` responses no-store via `rest_post_dispatch`, so proxies that respect origin headers stop caching them. The namespace check that `silence_error_display` already did is now a shared `is_plugin_route()` helper.

### 2. Opening a project bounces to the previously opened project

Closes weDevsOfficial/pm-pro#494

With a task sheet open, clicking a different project landed back on the old project with the old sheet open. `TaskDetailSheet` derives its project id from the open task, and the task-lists branch of the URL-sync effect was the only one not comparing that id with the project id in the URL, so it rewrote `/projects/<clicked>/task-lists` to `/projects/<open task's project>/task-lists/tasks/<id>`. Navigating to a different project now closes the sheet.

### 3. Kanban column counts stale after a drag, and the drop announced as "undefined"

Closes weDevsOfficial/pm-pro#496

Dragging a card to another column left both counts on their old numbers until the board was fetched again, and the live region announced `Dropped the card "X" into the "undefined" column`.

- `moveTaskBetweenBoards` moved the task between the board arrays but never touched `tasksMeta.pagination`, and the column header prefers `pagination.total`. The reducer now adjusts total and count on both boards.
- The announcements looked the column up by `over.id`, which is a card id when a card is dropped on another card. They now resolve through that card, the way `handleDragOver` already does.

Verified locally: In Progress 9 to 8 and Done 28 to 29 immediately after the drop, announcement reads the real column name, and the board API agrees (Done total 29 with the card in it).

## Testing

Built both plugins, uploaded the zips to the live FlyWP site, and re-ran the flows there with no page refresh:

- Task sheet: status, dates, assignees, estimate, type, milestone, privacy, label, recurring, sprint, description, subtasks, comments, activity, title rename. All render immediately, survive close/reopen, and match the server.
- Sprint assign/remove reflects on the Sprints page without a reload.
- Project, task list, task, milestone, discussion, category and sprint creation all appear immediately.
- A task type added in Settings shows up in the task sheet type picker with no reload.
- Kanban "add existing task" moves the count 0 to 1 and persists across navigation.
- Assigning a task updates My Tasks (1 to 2) with no reload.
- Locally, with `max-age=3600` injected into every wp-json GET to reproduce the host behaviour, an assignee edit now survives close/reopen. Before the fix the same scenario failed.
- Same-project sheet open/close still pushes and restores the URL as before.

## Note for the site owner

The header rewrite is a server configuration issue on that install: `/wp-json/` and `/wp-admin/admin.php` return `max-age=3600` while `admin-ajax.php` keeps WordPress's own no-store headers. Worth fixing there too, but the plugin should not depend on it.

https://claude.ai/code/session_01W398QZ8hB1bf1asSrAc26k
