### PR TITLE
fix: include year in date display (comments, overview, lists) [FREE]

### DIFF
--- a/views/assets/src/components/KanbanBoard/parts/KanbanBoardColumn.jsx
+++ b/views/assets/src/components/KanbanBoard/parts/KanbanBoardColumn.jsx
@@ -502,7 +502,7 @@ export default function KanbanBoardColumn({
                         {newTaskDueDate
                           ? new Date(newTaskDueDate).toLocaleDateString(
                               undefined,
-                              { month: "short", day: "numeric" },
+                              { month: "short", day: "numeric", year: "numeric" },
                             )
                           : __("Due date", 'wedevs-project-manager')}
                       </span>

--- a/views/assets/src/components/my-tasks/MyTasksPage/index.jsx
+++ b/views/assets/src/components/my-tasks/MyTasksPage/index.jsx
@@ -641,7 +641,7 @@ export default function MyTasksPage() {
                   <ResponsiveContainer width="100%" height="100%">
                     <LineChart
                       data={graph.map((d) => ({
-                        date: formatPmDate(d.date_time),
+                        date: formatPmDate(d.date_time, { month: "short", day: "numeric" }),
                         tasks: d.tasks || 0,
                         activities: d.activities || 0,
                       }))}

--- a/views/assets/src/components/projects/ProjectOverview.jsx
+++ b/views/assets/src/components/projects/ProjectOverview.jsx
@@ -358,7 +358,7 @@ export default function ProjectOverview() {
         (() => {
           const chartData = graph.map((day) => ({
             date: day.date_time?.date || "",
-            label: formatPmDate(day.date_time),
+            label: formatPmDate(day.date_time, { month: "short", day: "numeric" }),
             tasks: day.tasks || 0,
             activities: day.activities || 0,
           }));

--- a/views/assets/src/lib/pm-utils.js
+++ b/views/assets/src/lib/pm-utils.js
@@ -74,7 +74,7 @@ export function formatPmDate(field, options) {
   if (!dateStr) return ''
   const d = new Date(dateStr)
   if (isNaN(d.getTime())) return ''
-  return d.toLocaleDateString('en-US', options ?? { month: 'short', day: 'numeric' })
+  return d.toLocaleDateString('en-US', options ?? { month: 'short', day: 'numeric', year: 'numeric' })
 }
 
 /**
@@ -88,7 +88,7 @@ export function formatPmDateTime(field) {
   if (!dateStr) return ''
   const d = new Date(dateStr)
   if (isNaN(d.getTime())) return ''
-  const datePart = d.toLocaleDateString('en-US', { month: 'short', day: 'numeric' })
+  const datePart = d.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' })
   const timePart = d.toLocaleTimeString('en-US', { hour: '2-digit', minute: '2-digit', hour12: true }).toLowerCase()
   return `${datePart}, ${timePart}`
 }


### PR DESCRIPTION
## Summary

Fixes weDevsOfficial/pm-pro#497 - dates rendered through the shared date helpers were missing the year (e.g. `Aug 28` instead of `Aug 28, 2026`), which made items hard to place in projects and client histories that span multiple years.

## Changes

- `views/assets/src/lib/pm-utils.js`: `formatPmDate` (default options) and `formatPmDateTime` (date part) now include `year: 'numeric'`. This is the root fix and covers task due dates, project created dates, comments, discussions, files, milestones and notifications.
- Project overview + my-tasks 30-day activity charts pass an explicit no-year option, keeping the short `MMM d` tick labels. Every point falls inside a single-month window, so the year would only clutter the axis. This answers the maintainer's "is there a reason to show without a year?" question: yes, for the rolling charts.
- Kanban due-date picker chip aligned to the same `MMM d, yyyy` format.

Net diff: 4 files, 5 lines.

## Testing

Built the bundle and verified in the browser (WP admin, React UI):

- Project cards / created dates -> `Aug 24, 2026`
- Discussion + comment timestamps -> `Jul 13, 2026, 03:52 pm`
- 30-day overview chart axis -> `Aug 8 ... Sep 5` (short, intentionally unchanged)

## Issue

Closes weDevsOfficial/pm-pro#497

https://claude.ai/code/session_01PsKkoH3J6MwAvEBgd7aUvG
