### PR TITLE
fix: contain long/unbreakable content inside modals [FREE]

### DIFF
--- a/views/assets/src/components/ui/alert-dialog.jsx
+++ b/views/assets/src/components/ui/alert-dialog.jsx
@@ -30,7 +30,7 @@ const AlertDialogContent = React.forwardRef(({ className, ...props }, ref) => (
       ref={ref}
       data-pm-alert-content=""
       className={cn(
-        "fixed z-50 grid w-full max-w-sm gap-4 border bg-background p-6 shadow-xl rounded-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95",
+        "fixed z-50 grid grid-cols-[minmax(0,1fr)] [&>*]:min-w-0 w-full max-w-sm gap-4 border bg-background p-6 shadow-xl rounded-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95",
         className
       )}
       {...props}

--- a/views/assets/src/components/ui/dialog.jsx
+++ b/views/assets/src/components/ui/dialog.jsx
@@ -32,7 +32,7 @@ const DialogContent = React.forwardRef(({ className, children, ...props }, ref) 
     <DialogPrimitive.Content
       ref={ref}
       className={cn(
-        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background text-foreground p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
+        "fixed left-[50%] top-[50%] z-50 grid grid-cols-[minmax(0,1fr)] [&>*]:min-w-0 w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background text-foreground p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
         className
       )}
       {...props}>


### PR DESCRIPTION
## Summary

Long, unbreakable strings (e.g. a file name in the board-background attach row) overflowed **outside** modals instead of truncating inside them.

## Cause

`DialogContent` and `AlertDialogContent` are CSS grids. Grid items default to `min-width: auto`, so a long unbreakable string forces the grid track wider than the modal's `max-w`, and the content spills past the modal edge (measured: a 496px dialog with an 867px content track). The inner `truncate` never engages because its flex/grid ancestors are not width-constrained.

## Fix

On both `DialogContent` and `AlertDialogContent`:

- `grid-cols-[minmax(0,1fr)]` - make the single column shrinkable (cap at container width).
- `[&>*]:min-w-0` - let the direct children shrink below their min-content, so the inner `truncate` engages.

App-wide: every Dialog and AlertDialog now contains long content instead of overflowing. 2 files, 2 lines.

## Testing

Built and verified in the browser (Kanban board background modal, long file name):

- Before: file row + drop zone spilled ~370px past the modal's right edge.
- After: file name truncates with an ellipsis, size + remove button stay inside the modal.

Note for a Pro-active site: Pro owns the loaded stylesheet (`pm-pro.css`), and Pro's Tailwind scans the Free src, so these utilities land in `pm-pro.css` on the next Pro build (no Pro source change - `pm-pro/ui/dialog.jsx` re-exports Free's Dialog via `window.PM`).

https://claude.ai/code/session_01PsKkoH3J6MwAvEBgd7aUvG
